### PR TITLE
Convert to ANSI256 colors instead of using RGB colors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -211,6 +211,7 @@ dependencies = [
  "crossterm",
  "itertools",
  "rand",
+ "rgb2ansi256",
  "serde",
  "serde_json",
 ]
@@ -425,6 +426,12 @@ checksum = "4722d768eff46b75989dd134e5c353f0d6296e5aaa3132e776cbdb56be7731aa"
 dependencies = [
  "bitflags 1.3.2",
 ]
+
+[[package]]
+name = "rgb2ansi256"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ebca96b1c05912d531790498048bab5b7b97a756a7bb9df71fa4ef7ef9814e1"
 
 [[package]]
 name = "ryu"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,3 +13,4 @@ itertools = "0.12.1"
 rand = "0.8.3"
 serde = { version = "1.0.209", features = ["derive"] }
 serde_json = "1.0.127"
+rgb2ansi256 = "0.1"

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,4 @@
 use clap::Parser;
-use rgb2ansi256::rgb_to_ansi256;
 use crossterm::{
     cursor,
     event::{self, Event, KeyCode, KeyEvent, KeyEventKind, KeyModifiers},
@@ -10,6 +9,7 @@ use filters::Filter;
 use layout::Layout;
 use puzzle::{ax, Puzzle, PuzzleTurn, SideTurn, Turn};
 use rand::rngs::ThreadRng;
+use rgb2ansi256::rgb_to_ansi256;
 use serde::{Deserialize, Serialize};
 use std::fs::File;
 use std::io::BufReader;
@@ -65,7 +65,7 @@ const POS_COLORS: &[Color] = &[
     hex(0x0aaa85),
     hex(0x774811),
     hex(0xf49fef),
-    hex(0xb29867),
+    hex(0xf9c254),
     hex(0x9cf542),
     hex(0x078517),
 ];

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,5 @@
 use clap::Parser;
+use rgb2ansi256::rgb_to_ansi256;
 use crossterm::{
     cursor,
     event::{self, Event, KeyCode, KeyEvent, KeyEventKind, KeyModifiers},
@@ -23,11 +24,11 @@ mod layout;
 mod puzzle;
 
 const fn hex(hex: u32) -> Color {
-    Color::Rgb {
-        r: ((hex >> 16) & 0xff) as u8,
-        g: ((hex >> 8) & 0xff) as u8,
-        b: ((hex >> 0) & 0xff) as u8,
-    }
+    Color::AnsiValue(rgb_to_ansi256(
+        ((hex >> 16) & 0xff) as u8,
+        ((hex >> 8) & 0xff) as u8,
+        ((hex >> 0) & 0xff) as u8,
+    ))
 }
 
 const POS_NAMES: &[char] = &['R', 'U', 'F', 'O', 'A', 'Γ', 'Θ', 'Ξ', 'Σ', 'Ψ'];


### PR DESCRIPTION
ANSI256 colors have better support than 24-bit RGB colors, so this automatically converts all of the RGB hex colors their closest ANSI256 equivalents before trying to display anything.

The default terminal on MacOS does not support RGB, but does support ANSI256. Anything that supports RGB should also support ANSI256.