### PR TITLE
Smarter saving

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -261,8 +261,8 @@ impl AppState {
         } else if c == self.prefs.global_keys.save {
             match self.save() {
                 Ok(()) => self.message = Some(format!("saved to {}", self.filename.display())),
-                Err(err) => self.message = Some(format!("could not save: {}", err)),
-                //Err(_err) => self.message = Some("could not save".to_string()),
+                //Err(err) => self.message = Some(format!("could not save: {}", err)),
+                Err(_err) => self.message = Some("could not save".to_string()),
             }
         } else {
             match self.mode {


### PR DESCRIPTION
When you save, it will write into the file of the log you passed in with --log, but use the regular file creation if it wasn't passed in. If you reset or rescramble the puzzle and save, it will use a newly generated file when you so it won't overwrite the log file from the previous solve.