### PR TITLE
Add viewport panning, commus shortcut, and rotation refactor

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -204,7 +204,7 @@ checksum = "11157ac094ffbdde99aa67b23417ebdd801842852b500e395a45a9c0aac03e4a"
 
 [[package]]
 name = "flat-hypercube"
-version = "1.0.0"
+version = "2026.5.22"
 dependencies = [
  "chrono",
  "clap",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -242,7 +242,7 @@ checksum = "11157ac094ffbdde99aa67b23417ebdd801842852b500e395a45a9c0aac03e4a"
 
 [[package]]
 name = "flat-hypercube"
-version = "2026.5.29"
+version = "2026.6.5"
 dependencies = [
  "chrono",
  "clap",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -85,6 +85,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf4b9d6a944f767f8e5e0db018570623c85f3d925ac718db4e06d0187adb21c1"
 
 [[package]]
+name = "block2"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdeb9d870516001442e364c5220d3574d2da8dc765554b4a617230d33fa58ef5"
+dependencies = [
+ "objc2",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -104,6 +113,12 @@ name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
+name = "cfg_aliases"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "chrono"
@@ -197,6 +212,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "ctrlc"
+version = "3.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0b1fab2ae45819af2d0731d60f2afe17227ebb1a1538a236da84c93e9a60162"
+dependencies = [
+ "dispatch2",
+ "nix",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "dispatch2"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e0e367e4e7da84520dedcac1901e4da967309406d1e51017ae1abfb97adbd38"
+dependencies = [
+ "bitflags 2.5.0",
+ "block2",
+ "libc",
+ "objc2",
+]
+
+[[package]]
 name = "either"
 version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -209,6 +247,7 @@ dependencies = [
  "chrono",
  "clap",
  "crossterm",
+ "ctrlc",
  "itertools",
  "rand",
  "rgb2ansi256",
@@ -288,9 +327,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.153"
+version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c198f91728a82281a64e1f4f9eeb25d82cb32a5de251c6bd1b5154d63a8e7bd"
+checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
 name = "lock_api"
@@ -327,6 +366,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "nix"
+version = "0.31.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf20d2fde8ff38632c426f1165ed7436270b44f199fc55284c38276f9db47c3d"
+dependencies = [
+ "bitflags 2.5.0",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
+]
+
+[[package]]
 name = "num-traits"
 version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -334,6 +385,21 @@ checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
 ]
+
+[[package]]
+name = "objc2"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a12a8ed07aefc768292f076dc3ac8c48f3781c8f2d5851dd3d98950e8c5a89f"
+dependencies = [
+ "objc2-encode",
+]
+
+[[package]]
+name = "objc2-encode"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef25abbcd74fb2609453eb695bd2f860d389e457f67dc17cafc8b8cbc89d0c33"
 
 [[package]]
 name = "once_cell"
@@ -641,6 +707,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-link"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
 name = "windows-sys"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -656,6 +728,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
  "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.61.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
+dependencies = [
+ "windows-link",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -242,7 +242,7 @@ checksum = "11157ac094ffbdde99aa67b23417ebdd801842852b500e395a45a9c0aac03e4a"
 
 [[package]]
 name = "flat-hypercube"
-version = "2026.5.22"
+version = "2026.5.29"
 dependencies = [
  "chrono",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "flat-hypercube"
-version = "1.0.0"
+version = "2026.5.22"
 edition = "2024"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "flat-hypercube"
-version = "2026.5.22"
+version = "2026.5.29"
 edition = "2024"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "flat-hypercube"
-version = "2026.5.29"
+version = "2026.6.5"
 edition = "2024"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ edition = "2024"
 chrono = "0.4.38"
 clap = { version = "4.5.16", features = ["derive"] }
 crossterm = "0.27.0"
+ctrlc = "3.4"
 itertools = "0.12.1"
 rand = "0.8.3"
 serde = { version = "1.0.215", features = ["derive"] }

--- a/README.md
+++ b/README.md
@@ -1,18 +1,19 @@
 ## Flat hypercube simulator
 
-This is a program that allows you to solve hypercubes in up to 10 dimensions using a flat projection. It supports keybinds.
+This is a program that allows you to solve hypercubes in any number of dimensions using a flat projection, by providing a custom prefs file that defines additional axes. It supports keybinds.
 
-The projection is recursive in the number of dimensions. A puzzle of dimension 0 just has a single piece with no stickers: the core. When a dimension is added, multiple copies of the previous dimension's puzzle are placed next to each other, along with a cap on either end. In each cap, the stickers from the lower-dimensional puzzle have been removed and the stickers have been replaced with pieces. The middle puzzles represent the layers of the puzzle along the new dimension, and the caps represent the two new facets added along this direction. The layout was inspired by Don Hatch's layout in [MagicCubeNdSolve](http://www.plunk.org/~hatch/MagicCubeNdSolve/).
+The projection is recursive in the number of dimensions. When a dimension is added, multiple copies of the previous dimension's puzzle are placed next to each other, along with a cap on either end. In each cap, the stickers from the lower-dimensional puzzle have been removed and the stickers have been replaced with pieces. The middle puzzles represent the layers of the puzzle along the new dimension, and the caps represent the two new facets added along this direction. The layout was inspired by Don Hatch's layout in [MagicCubeNdSolve](http://www.plunk.org/~hatch/MagicCubeNdSolve/).
 
 ### Use
 
-To start the program, download it from [releases](https://github.com/milojacquet/flat-hypercube/releases/latest) and run it with the arguments `[n] [d]` to produce an `n^d` puzzle. Use `--compact` to move the stickers closer to each other, which can help on smaller screens.
+To start the program, run it with the arguments `[n] [d]` to produce an `n^d` puzzle. Use `--compact` or `-c` to move the stickers closer to each other, which can help on smaller screens. You can pan the viewport by dragging with the mouse, using arrow keys, or scrolling with the touchpad.
 
 This program supports multiple methods of interaction. In all modes, pressing <kbd>=</kbd> 5 times scrambles the puzzle, and pressing <kbd>-</kbd> 5 times resets the puzzle. <kbd>Ctrl</kbd>+<kbd>C</kbd> quits the program. <kbd>Z</kbd> undoes the most recent move, and <kbd>Shift</kbd>+<kbd>Z</kbd> redoes it. 
 
 There are multiple systems to turn the puzzle. <kbd>\\</kbd> cycles between them. In all of them, using <kbd>1</kbd> through <kbd>9</kbd> before a turn sequence selects the layer of the puzzle starting from the outermost.
 
-Each side has several keys that can be used to access it in different contexts. The selector is usually used at the beginning of the key combination to select which side to turn. The other set of keys is used to determine which direction the side should turn. When in axis mode, these keys only refer to the positive direction on each axis, and when in side mode, there are keys for both sides. Axis mode and side mode can be toggled with <kbd>Shift</kbd>+<kbd>\\</kbd>. 
+Each side has several keys that can be used to access it in different contexts. The selector is usually used at the beginning of the key combination to select which side to turn. The other set of keys is used to determine which direction the side should turn. When in axis mode, these keys only refer to the positive direction on each axis, and when in side mode, there are keys for both sides. Axis mode and side mode can be toggled with <kbd>Shift</kbd>+<kbd>\\</kbd>. The table below shows the default keybindings provided by `default_prefs.json`; custom prefs files can define different keys and additional axes.
+
 | Side (+/-) | Selector | Axis mode | Side mode |
 | -------- | ------- | ------- | ------- |
 | R, L | <kbd>F</kbd>, <kbd>S</kbd> | <kbd>K</kbd> | <kbd>L</kbd>, <kbd>U</kbd> |

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ The projection is recursive in the number of dimensions. When a dimension is add
 
 To start the program, run it with the arguments `[n] [d]` to produce an `n^d` puzzle. Use `--compact` or `-c` to move the stickers closer to each other, which can help on smaller screens. You can pan the viewport by dragging with the mouse, using arrow keys, or scrolling with the touchpad.
 
-This program supports multiple methods of interaction. In all modes, pressing <kbd>=</kbd> 5 times scrambles the puzzle, and pressing <kbd>-</kbd> 5 times resets the puzzle. <kbd>Ctrl</kbd>+<kbd>C</kbd> quits the program. <kbd>Z</kbd> undoes the most recent move, and <kbd>Shift</kbd>+<kbd>Z</kbd> redoes it. 
+This program supports multiple methods of interaction. In all modes, pressing <kbd>=</kbd> 5 times scrambles the puzzle, and pressing <kbd>-</kbd> 5 times resets the puzzle. <kbd>Ctrl</kbd>+<kbd>C</kbd> quits the program (press twice for forced quit). <kbd>Z</kbd> undoes the most recent move, and <kbd>Shift</kbd>+<kbd>Z</kbd> redoes it.
 
 There are multiple systems to turn the puzzle. <kbd>\\</kbd> cycles between them. In all of them, using <kbd>1</kbd> through <kbd>9</kbd> before a turn sequence selects the layer of the puzzle starting from the outermost.
 
@@ -31,11 +31,28 @@ Each side has several keys that can be used to access it in different contexts. 
 
 This mode is most similar to Magic Cube 7D. To make a turn, first use the side selector, then two axis keys to perform the turn that takes the first axis to the second axis. If you use <kbd>X</kbd> instead of the side selector, you can do a whole-puzzle rotation. Once you complete a move, you can continue to use axis keys to do additional moves on the same side.
 
+**Three-key strict mode** requires every key in the sequence to be a selector key — no axis keys or side keys are used. After each turn the state is fully reset; layer selections and `x` do not persist between turns.
+
+In **side mode**, whole-puzzle rotations respect the sign of each axis key: pressing a positive side key for one axis and a negative side key for the other produces the inverse rotation of pressing both positive.
+
 #### Fixed-key mode
 
-In this mode, first use the side selector, then use enough axis keys to fix the rotation to occur in a plane. Once you complete a move, you can continue to use axis keys to do additional moves on the same side. To do a whole-puzzle rotation, include <kbd>X</kbd> somewhere in the sequence before the end. Once you complete a move, you can continue to use axis keys to do additional moves on the same side.
+In this mode, first use the side selector, then use enough axis keys to fix the rotation to occur in a plane. Once you complete a move, you can continue to use axis keys to do additional moves on the same side. For a whole-puzzle rotation, press <kbd>X</kbd> as the first key in the sequence — it replaces the side selector and requires one additional axis key (d−2 total instead of d−3).
 
 In three dimensions, just pressing a side selector key rotates that side counterclockwise. To rotate it clockwise, use the corresponding face selector key from side mode.
+
+### Commutators and conjugators
+
+<kbd>F1</kbd> starts a reversion block and <kbd>F2</kbd> ends it. The block is displayed on the second-to-last row as `RevStack: [n]` where `n` is the number of moves in the block.
+
+- <kbd>F3</kbd> performs an **undo** of the block: applies the inverse of each move in reverse order.
+- <kbd>F4</kbd> performs a **commutator**: applies the inverse of the block, then the inverse of all moves after the block. This is equivalent to undoing the moves before the block, performing them, then undoing everything — useful for checking commutativity.
+
+The RevStack display adapts automatically when you undo or redo moves that cross block boundaries.
+
+### Marking stickers
+
+Click a sticker to mark it and its neighboring stickers with brackets. The marking happens on mouse **release**, so you can drag to pan without accidentally marking. Double-click on empty space to clear all marks.
 
 ### Saving and loading
 

--- a/README.md
+++ b/README.md
@@ -16,16 +16,18 @@ Each side has several keys that can be used to access it in different contexts. 
 
 | Side (+/-) | Selector | Axis mode | Side mode |
 | -------- | ------- | ------- | ------- |
-| R, L | <kbd>F</kbd>, <kbd>S</kbd> | <kbd>K</kbd> | <kbd>L</kbd>, <kbd>U</kbd> |
-| U, D | <kbd>E</kbd>, <kbd>D</kbd> | <kbd>J</kbd> | <kbd>I</kbd>, <kbd>,</kbd> |
-| F, B | <kbd>R</kbd>, <kbd>W</kbd> | <kbd>L</kbd> | <kbd>J</kbd>, <kbd>O</kbd> |
-| O, I | <kbd>T</kbd>, <kbd>G</kbd> | <kbd>I</kbd> | <kbd>.</kbd>, <kbd>K</kbd> |
-| A, P | <kbd>V</kbd>, <kbd>C</kbd> | <kbd>U</kbd> | <kbd>P</kbd>, <kbd>L</kbd> |
-| Γ, Δ | <kbd>Y</kbd>, <kbd>H</kbd> | <kbd>O</kbd> | <kbd>[</kbd>, <kbd>;</kbd> |
-| Θ, Λ | <kbd>N</kbd>, <kbd>B</kbd> | <kbd>P</kbd> | N/A |
-| Ξ, Π | <kbd>Q</kbd>, <kbd>A</kbd> | <kbd>;</kbd> | N/A |
-| Σ, Φ | <kbd>,</kbd>, <kbd>M</kbd> | <kbd>[</kbd> | N/A |
-| Ψ, Ω | <kbd>/</kbd>, <kbd>.</kbd> | <kbd>'</kbd> | N/A |
+| R, L | <kbd>F</kbd>, <kbd>S</kbd> | <kbd>K</kbd> | <kbd>L</kbd>, <kbd>J</kbd> |
+| U, D | <kbd>E</kbd>, <kbd>D</kbd> | <kbd>J</kbd> | <kbd>I</kbd>, <kbd>K</kbd> |
+| F, B | <kbd>R</kbd>, <kbd>W</kbd> | <kbd>L</kbd> | <kbd>O</kbd>, <kbd>U</kbd> |
+| O, I | <kbd>T</kbd>, <kbd>G</kbd> | <kbd>I</kbd> | <kbd>P</kbd>, <kbd>;</kbd> |
+| A, P | <kbd>V</kbd>, <kbd>C</kbd> | <kbd>U</kbd> | <kbd>.</kbd>, <kbd>,</kbd> |
+| Γ, Δ | <kbd>Y</kbd>, <kbd>H</kbd> | <kbd>O</kbd> | <kbd>[</kbd>, <kbd>'</kbd> |
+| Θ, Λ | <kbd>N</kbd>, <kbd>B</kbd> | <kbd>P</kbd> | <kbd>N</kbd>, <kbd>M</kbd> |
+| Ξ, Π | <kbd>Q</kbd>, <kbd>A</kbd> | <kbd>;</kbd> | <kbd>Y</kbd>, <kbd>H</kbd> |
+| Σ, Φ | <kbd>,</kbd>, <kbd>M</kbd> | <kbd>[</kbd> | <kbd>T</kbd>, <kbd>G</kbd> |
+| Ψ, Ω | <kbd>/</kbd>, <kbd>.</kbd> | <kbd>'</kbd> | <kbd>V</kbd>, <kbd>B</kbd> |
+
+Keys within the same column must be unique (e.g. all selector keys must differ from each other), but keys *between* columns may overlap — a key can be a selector on one axis and an axis or side key on another.
 
 #### Three-key mode
 
@@ -37,9 +39,9 @@ In **side mode**, whole-puzzle rotations respect the sign of each axis key: pres
 
 #### Fixed-key mode
 
-In this mode, first use the side selector, then use enough axis keys to fix the rotation to occur in a plane. Once you complete a move, you can continue to use axis keys to do additional moves on the same side. For a whole-puzzle rotation, press <kbd>X</kbd> as the first key in the sequence — it replaces the side selector and requires one additional axis key (d−2 total instead of d−3).
+In this mode, first use a selector key to choose which side to turn, then press enough axis keys (or side keys in side mode) to fix the rotation to a plane. Once a move completes, you can continue to press axis keys for additional moves on the same side. For a whole-puzzle rotation, press <kbd>X</kbd> first — it replaces the selector and requires one extra axis key (d−2 total instead of d−3).
 
-In three dimensions, just pressing a side selector key rotates that side counterclockwise. To rotate it clockwise, use the corresponding face selector key from side mode.
+In three dimensions, just pressing a **selector** key immediately rotates that face counterclockwise; the negative selector key rotates it clockwise. Press <kbd>X</kbd> before the selector key to rotate the whole puzzle instead. Layer selections and <kbd>X</kbd> persist across turns until explicitly cleared by <kbd>Esc</kbd> or another layer key.
 
 ### Commutators and conjugators
 

--- a/default_prefs.json
+++ b/default_prefs.json
@@ -147,7 +147,7 @@
                 "keys":
                 {
                     "select": "n",
-                    "side": "∅"
+                    "side": "n"
                 }
             },
             "neg":
@@ -157,7 +157,7 @@
                 "keys":
                 {
                     "select": "b",
-                    "side": "∅"
+                    "side": "m"
                 }
             },
             "axis_key": "p"
@@ -170,7 +170,7 @@
                 "keys":
                 {
                     "select": "q",
-                    "side": "∅"
+                    "side": "y"
                 }
             },
             "neg":
@@ -180,7 +180,7 @@
                 "keys":
                 {
                     "select": "a",
-                    "side": "∅"
+                    "side": "h"
                 }
             },
             "axis_key": ";"
@@ -193,7 +193,7 @@
                 "keys":
                 {
                     "select": ",",
-                    "side": "∅"
+                    "side": "t"
                 }
             },
             "neg":
@@ -203,7 +203,7 @@
                 "keys":
                 {
                     "select": "m",
-                    "side": "∅"
+                    "side": "g"
                 }
             },
             "axis_key": "["
@@ -216,7 +216,7 @@
                 "keys":
                 {
                     "select": "/",
-                    "side": "∅"
+                    "side": "v"
                 }
             },
             "neg":
@@ -226,7 +226,7 @@
                 "keys":
                 {
                     "select": ".",
-                    "side": "∅"
+                    "side": "b"
                 }
             },
             "axis_key": "'"

--- a/default_prefs.json
+++ b/default_prefs.json
@@ -257,7 +257,11 @@
         "prev_filter": "J",
         "live_filter_mode": "F",
         "reset_mode": "⎋",
-        "save": "S"
+        "save": "S",
+        "rev_start": "Q",
+        "rev_stop": "W",
+        "rev_unwind": "E",
+        "rev_commutator": "R"
     },
     "global_colors":
     {

--- a/src/layout.rs
+++ b/src/layout.rs
@@ -1,9 +1,74 @@
 use std::collections::HashMap;
 use std::iter::once;
 
-const GAPS: &[i16] = &[0, 1, 0, 2, 1, 10, 4, 40, 18, 160, 72];
-const GAPS_SEMI: &[i16] = &[0, 1, 0, 2, 1, 3, 1, 3, 1, 3, 1];
-const GAPS_COMPACT: &[i16] = &[0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0];
+const RATIO: i16 = 2; // terminal char aspect ratio: ~0.5 width/height
+
+fn compute_gaps(n: i16, max_d: u16, semi_compact: bool, compact: bool) -> Vec<i16> {
+    let max_idx = max_d as usize + 2; // +2 for vertical-mode d+1 access
+    let mut gaps = vec![0i16; max_idx];
+
+    if compact {
+        for d in 0..max_idx {
+            gaps[d] = if d % 2 == 0 { 0 } else { 1 };
+        }
+        return gaps;
+    }
+
+    if semi_compact {
+        // first 5: [0, 1, 0, 2, 1], then alternating 3, 1, 3, 1...
+        gaps[0] = 0;
+        gaps[1] = 1;
+        gaps[2] = 0;
+        gaps[3] = 2;
+        gaps[4] = 1;
+        for d in 5..max_idx {
+            gaps[d] = if d % 2 == 0 { 1 } else { 3 };
+        }
+        return gaps;
+    }
+
+    // Regular mode: first 5 fixed
+    gaps[0] = 0;
+    gaps[1] = 1;
+    gaps[2] = 0;
+    gaps[3] = 2;
+    gaps[4] = 1;
+
+    if max_idx <= 6 {
+        return gaps;
+    }
+
+    // C[d] = cavity height, O[d] = outer sticker height (even d only)
+    let mut c = vec![0i16; max_idx];
+    let mut o = vec![0i16; max_idx];
+
+    c[2] = n;
+    o[2] = 1;
+    // C(4) = n * C(2) + (n-1) * (2*O(2) + gap[4])
+    c[4] = n * c[2] + (n - 1) * (2 * o[2] + gaps[4]);
+    o[4] = c[2];
+
+    // accumulator = O(2) + Σ_{even k, 4≤k≤d-4} (O(k) + gap[k])
+    let mut acc = o[2];
+
+    for d in (6..max_idx).step_by(2) {
+        gaps[d] = gaps[d - 2] + 2 * acc + 1;
+
+        // acc_c = acc + C(d-4) + gap(d-2) = O(2) + Σ_{even k, 4≤k≤d-2} (C(k-2) + gap[k])
+        let acc_c = acc + c[d - 4] + gaps[d - 2];
+        let t = gaps[d] + 2 * acc_c;
+        c[d] = n * c[d - 2] + (n - 1) * t;
+        o[d] = c[d - 2];
+
+        acc += c[d - 4] + gaps[d - 2];
+    }
+
+    for d in (5..max_idx.saturating_sub(1)).step_by(2) {
+        gaps[d] = gaps[d + 1] * RATIO;
+    }
+
+    gaps
+}
 
 #[derive(Debug, Clone)]
 pub struct Layout {
@@ -141,8 +206,11 @@ impl Layout {
     }
 
     pub fn make_layout(n: i16, d: u16, semi_compact: bool, compact: bool, vertical: bool) -> Layout {
-        let gaps = if compact { GAPS_COMPACT } else if semi_compact { GAPS_SEMI } else { GAPS };
+        let gaps = compute_gaps(n, d, semi_compact, compact);
+        Self::make_layout_inner(n, d, vertical, &gaps)
+    }
 
+    fn make_layout_inner(n: i16, d: u16, vertical: bool, gaps: &[i16]) -> Layout {
         if d == 0 {
             Layout {
                 width: 1,
@@ -157,7 +225,7 @@ impl Layout {
         } else {
             let make_horizontal = d % 2 == 1 && !vertical;
 
-            let lower = Self::make_layout(n, ((d as i16) - 1) as u16, semi_compact, compact, false);
+            let lower = Self::make_layout_inner(n, d - 1, false, gaps);
             let mut row = vec![];
 
             for i in once(-n).chain((-n + 1..n).step_by(2)).chain(once(n)) {
@@ -186,11 +254,13 @@ impl Layout {
 
                 row.push(lower);
             }
+            let gap_idx = d as usize
+                + if vertical && d % 2 == 1 { 1 } else { 0 };
             if make_horizontal {
-                Self::concat_horiz(row, gaps[d as usize])
+                Self::concat_horiz(row, gaps[gap_idx])
             } else {
                 row.reverse();
-                Self::concat_vert(row, gaps[d as usize])
+                Self::concat_vert(row, gaps[gap_idx])
             }
         }
     }

--- a/src/layout.rs
+++ b/src/layout.rs
@@ -4,7 +4,7 @@ use std::iter::once;
 const RATIO: i16 = 2; // terminal char aspect ratio: ~0.5 width/height
 
 fn compute_gaps(n: i16, max_d: u16, semi_compact: bool, compact: bool) -> Vec<i16> {
-    let max_idx = max_d as usize + 2; // +2 for vertical-mode d+1 access
+    let max_idx = (max_d as usize + 2).max(5); // +2 for vertical-mode d+1 access, min 5 for first-5 init
     let mut gaps = vec![0i16; max_idx];
 
     if compact {

--- a/src/layout.rs
+++ b/src/layout.rs
@@ -38,29 +38,17 @@ fn compute_gaps(n: i16, max_d: u16, semi_compact: bool, compact: bool) -> Vec<i1
         return gaps;
     }
 
-    // C[d] = cavity height, O[d] = outer sticker height (even d only)
+    // C[d] = cavity height (even d), c[0] = 1
     let mut c = vec![0i16; max_idx];
-    let mut o = vec![0i16; max_idx];
-
+    c[0] = 1;
     c[2] = n;
-    o[2] = 1;
-    // C(4) = n * C(2) + (n-1) * (2*O(2) + gap[4])
-    c[4] = n * c[2] + (n - 1) * (2 * o[2] + gaps[4]);
-    o[4] = c[2];
-
-    // accumulator = O(2) + Σ_{even k, 4≤k≤d-4} (O(k) + gap[k])
-    let mut acc = o[2];
+    // acc = c[0] + Σ_{even k, 4≤k≤d-2} (C(k-2) + gap[k])
+    let mut acc = 0;
 
     for d in (6..max_idx).step_by(2) {
+        acc += c[d - 6] + gaps[d - 4];
+        c[d - 2] = n * c[d - 4] + (n - 1) * (gaps[d - 2] + 2 * acc);
         gaps[d] = gaps[d - 2] + 2 * acc + 1;
-
-        // acc_c = acc + C(d-4) + gap(d-2) = O(2) + Σ_{even k, 4≤k≤d-2} (C(k-2) + gap[k])
-        let acc_c = acc + c[d - 4] + gaps[d - 2];
-        let t = gaps[d] + 2 * acc_c;
-        c[d] = n * c[d - 2] + (n - 1) * t;
-        o[d] = c[d - 2];
-
-        acc += c[d - 4] + gaps[d - 2];
     }
 
     for d in (5..max_idx.saturating_sub(1)).step_by(2) {

--- a/src/layout.rs
+++ b/src/layout.rs
@@ -2,6 +2,7 @@ use std::collections::HashMap;
 use std::iter::once;
 
 const GAPS: &[i16] = &[0, 1, 0, 2, 1, 10, 4, 40, 18, 160, 72];
+const GAPS_SEMI: &[i16] = &[0, 1, 0, 2, 1, 3, 1, 3, 1, 3, 1];
 const GAPS_COMPACT: &[i16] = &[0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0];
 
 #[derive(Debug, Clone)]
@@ -139,8 +140,8 @@ impl Layout {
         lower
     }
 
-    pub fn make_layout(n: i16, d: u16, compact: bool, vertical: bool) -> Layout {
-        let gaps = if compact { GAPS_COMPACT } else { GAPS };
+    pub fn make_layout(n: i16, d: u16, semi_compact: bool, compact: bool, vertical: bool) -> Layout {
+        let gaps = if compact { GAPS_COMPACT } else if semi_compact { GAPS_SEMI } else { GAPS };
 
         if d == 0 {
             Layout {
@@ -156,7 +157,7 @@ impl Layout {
         } else {
             let make_horizontal = d % 2 == 1 && !vertical;
 
-            let lower = Self::make_layout(n, ((d as i16) - 1) as u16, compact, false);
+            let lower = Self::make_layout(n, ((d as i16) - 1) as u16, semi_compact, compact, false);
             let mut row = vec![];
 
             for i in once(-n).chain((-n + 1..n).step_by(2)).chain(once(n)) {

--- a/src/layout.rs
+++ b/src/layout.rs
@@ -210,6 +210,8 @@ impl Layout {
                     HashMap::new()
                 },
             }
+        } else if n == 2 {
+            Self::make_layout_inner_n2(d, vertical, gaps)
         } else {
             let make_horizontal = d % 2 == 1 && !vertical;
 
@@ -250,6 +252,95 @@ impl Layout {
                 row.reverse();
                 Self::concat_vert(row, gaps[gap_idx])
             }
+        }
+    }
+
+    fn make_layout_inner_n2(d: u16, vertical: bool, gaps: &[i16]) -> Layout {
+        let make_horizontal = d % 2 == 1 && !vertical;
+        let lower = Self::make_layout_inner(2, d - 1, false, gaps);
+        let mut row = vec![];
+
+        for i in once(-2).chain(once(-1)).chain(once(1)).chain(once(2)) {
+            let mut layer = lower.clone().push_all(i).clean(2);
+            if i.abs() == 2 {
+                if make_horizontal {
+                    layer = layer.squish_horiz();
+                } else {
+                    layer = layer.squish_vert();
+                }
+            }
+
+            if i == -2 || i == 2 {
+                layer.keybind_hints.clear();
+            } else if d == 1 {
+                for ((x, y), pos) in layer.points.clone().iter() {
+                    if !pos.iter().any(|&v| v.abs() == 2) {
+                        layer.keybind_hints.insert((*x, *y), Some(if i == -1 { !0 } else { 0 }));
+                    }
+                }
+            } else if d == 2 {
+                let ns: Vec<(i16, i16)> = layer
+                    .points
+                    .iter()
+                    .filter(|(_, coords)| !coords.iter().any(|&v| v.abs() == 2))
+                    .map(|(&pos, _)| pos)
+                    .collect();
+                let min_x = ns.iter().map(|p| p.0).min().unwrap();
+                let max_x = ns.iter().map(|p| p.0).max().unwrap();
+                let row_y = ns[0].1;
+
+                layer.keybind_hints.clear();
+                if i == -1 {
+                    layer.keybind_hints.insert((min_x, row_y), Some(!1));
+                    layer.keybind_hints.insert((max_x, row_y), Some(0));
+                } else {
+                    layer.keybind_hints.insert((min_x, row_y), Some(!0));
+                    layer.keybind_hints.insert((max_x, row_y), Some(1));
+                }
+            } else {
+                if i == -1 {
+                    layer.keybind_hints.clear();
+                    Self::place_new_hints_n2(&mut layer, (d - 1) as i16, make_horizontal);
+                }
+            }
+
+            row.push(layer);
+        }
+
+        let gap_idx = d as usize + if vertical && d % 2 == 1 { 1 } else { 0 };
+        if make_horizontal {
+            Self::concat_horiz(row, gaps[gap_idx])
+        } else {
+            row.reverse();
+            Self::concat_vert(row, gaps[gap_idx])
+        }
+    }
+
+    /// Place both new-axis hints into the i=-1 layer (n=2, d≥3).
+    fn place_new_hints_n2(layer: &mut Layout, new_axis: i16, make_horizontal: bool) {
+        let mut ns: Vec<(i16, i16)> = layer
+            .points
+            .iter()
+            .filter(|(_, coords)| !coords.iter().any(|&v| v.abs() == 2))
+            .map(|(&pos, _)| pos)
+            .collect();
+
+        if ns.len() < 2 {
+            return;
+        }
+
+        if make_horizontal {
+            // topmost, then rightmost → top 1×2: left=neg, right=pos
+            ns.sort_by(|a, b| a.1.cmp(&b.1).then(b.0.cmp(&a.0)));
+            let (rx, ry) = ns[0];
+            layer.keybind_hints.insert((rx - 2, ry), Some(!new_axis));
+            layer.keybind_hints.insert((rx, ry), Some(new_axis));
+        } else {
+            // rightmost, then topmost → right 2×1: top=pos, bottom=neg
+            ns.sort_by(|a, b| b.0.cmp(&a.0).then(a.1.cmp(&b.1)));
+            let (rx, ry) = ns[0];
+            layer.keybind_hints.insert((rx, ry), Some(new_axis));
+            layer.keybind_hints.insert((rx, ry + 1), Some(!new_axis));
         }
     }
 }

--- a/src/prefs.rs
+++ b/src/prefs.rs
@@ -2,17 +2,14 @@
 use crossterm::style::Color;
 use serde::de::Error;
 use serde::Deserializer;
-use std::fs::File;
-use std::io::BufReader;
 use std::num::ParseIntError;
-use std::path::Path;
 
 use rgb2ansi256::rgb_to_ansi256;
 use serde::Deserialize;
 
 pub const ESCAPE_CODE: char = '⎋';
 pub const BACKSPACE_CODE: char = '⌫';
-pub const DEFAULT_FILE_PATH_STR: &'static str = "default_prefs.json";
+pub const DEFAULT_FILE_PATH_STR: &str = include_str!("../default_prefs.json");
 
 #[derive(Debug, Clone, Deserialize)]
 pub struct Prefs {
@@ -25,9 +22,7 @@ pub struct Prefs {
 
 impl Prefs {
     pub fn load_default() -> Result<Self, Box<dyn std::error::Error>> {
-        let file = File::open(Path::new(DEFAULT_FILE_PATH_STR))?;
-        let reader = BufReader::new(file);
-        Ok(serde_json::from_reader(reader)?)
+        Ok(serde_json::from_str(DEFAULT_FILE_PATH_STR)?)
     }
 
     pub fn pos_keys(&self) -> impl Iterator<Item = char> + '_ {

--- a/src/prefs.rs
+++ b/src/prefs.rs
@@ -36,6 +36,76 @@ impl Prefs {
     pub fn max_layers(&self) -> i16 {
         (self.global_keys.layers.len() * 2 + 1) as i16
     }
+
+    pub fn validate(&self) -> Result<(), String> {
+        use std::collections::HashSet;
+
+        // Same field across different (axis + direction) must be unique.
+        // select and side each span all pos/neg directions; axis_key spans all axes.
+        // Different fields (select vs side vs axis_key) never conflict.
+        let mut selects = HashSet::new();
+        let mut sides = HashSet::new();
+        for (i, ax) in self.axes.iter().enumerate() {
+            for (dir, keys) in [("pos", &ax.pos.keys), ("neg", &ax.neg.keys)] {
+                if keys.select != '∅' && !selects.insert(keys.select) {
+                    return Err(format!(
+                        "duplicate select key '{0}' in axis {i} {dir}",
+                        keys.select
+                    ));
+                }
+                if keys.side != '∅' && !sides.insert(keys.side) {
+                    return Err(format!(
+                        "duplicate side key '{0}' in axis {i} {dir}",
+                        keys.side
+                    ));
+                }
+            }
+        }
+
+        let mut axis_keys = HashSet::new();
+        for (i, ax) in self.axes.iter().enumerate() {
+            if ax.axis_key != '∅' && !axis_keys.insert(ax.axis_key) {
+                return Err(format!(
+                    "duplicate axis_key '{0}' in axis {i}",
+                    ax.axis_key
+                ));
+            }
+        }
+
+        // Any axis key must not conflict with global keys
+        let all: HashSet<char> = selects.iter()
+            .chain(sides.iter()).chain(axis_keys.iter()).copied().collect();
+        let gk = &self.global_keys;
+        for (i, &ch) in gk.layers.iter().enumerate() {
+            if all.contains(&ch) {
+                return Err(format!(
+                    "key '{ch}' in layer key[{i}] conflicts with an axis key"
+                ));
+            }
+        }
+        for (label, ch) in [
+            ("global rotate", gk.rotate),
+            ("global scramble", gk.scramble),
+            ("global reset", gk.reset),
+            ("global keybind_mode", gk.keybind_mode),
+            ("global axis_mode", gk.axis_mode),
+            ("global undo", gk.undo),
+            ("global redo", gk.redo),
+            ("global next_filter", gk.next_filter),
+            ("global prev_filter", gk.prev_filter),
+            ("global live_filter_mode", gk.live_filter_mode),
+            ("global reset_mode", gk.reset_mode),
+            ("global save", gk.save),
+        ] {
+            if all.contains(&ch) {
+                return Err(format!(
+                    "key '{ch}' in {label} conflicts with an axis key"
+                ));
+            }
+        }
+
+        Ok(())
+    }
 }
 
 #[derive(Debug, Clone, Deserialize)]

--- a/src/prefs.rs
+++ b/src/prefs.rs
@@ -96,6 +96,10 @@ impl Prefs {
             ("global live_filter_mode", gk.live_filter_mode),
             ("global reset_mode", gk.reset_mode),
             ("global save", gk.save),
+            ("global rev_start", gk.rev_start),
+            ("global rev_stop", gk.rev_stop),
+            ("global rev_unwind", gk.rev_unwind),
+            ("global rev_commutator", gk.rev_commutator),
         ] {
             if all.contains(&ch) {
                 return Err(format!(
@@ -156,6 +160,10 @@ pub struct GlobalKeys {
     pub live_filter_mode: char,
     pub reset_mode: char,
     pub save: char,
+    pub rev_start: char,
+    pub rev_stop: char,
+    pub rev_unwind: char,
+    pub rev_commutator: char,
 }
 
 fn hex(st: &str) -> Result<Color, ParseIntError> {

--- a/src/puzzle.rs
+++ b/src/puzzle.rs
@@ -184,7 +184,9 @@ impl Puzzle {
 
     fn puzzle_rotate(&mut self, turn: PuzzleTurn) -> Option<()> {
         let PuzzleTurn { from, to } = turn;
-        if from == to || from == !to {
+        let from = ax(from);
+        let to = ax(to);
+        if from == to {
             return None;
         }
 

--- a/src/state.rs
+++ b/src/state.rs
@@ -612,7 +612,9 @@ impl AppState {
     }
 
     pub fn make_layout(&self, semi_compact: bool, compact: bool, vertical: bool) -> Layout {
-        Layout::make_layout(self.puzzle.n, self.puzzle.d, semi_compact, compact, vertical).move_right(1)
+        let mut layout = Layout::make_layout(self.puzzle.n, self.puzzle.d, semi_compact, compact, vertical).move_right(1);
+        layout.width += 1; // reserve rightmost column for brackets
+        layout
     }
 
     pub fn process_key(&mut self, c: char) {
@@ -988,6 +990,7 @@ fn draw_brackets(
     prefs: &Prefs,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let color = prefs.global_colors.clicked;
+    let x = x.max(1);
     stdout
         .queue(cursor::MoveTo(x as u16 - 1, y as u16))?
         .queue(style::PrintStyledContent(style.open().with(color)))?
@@ -1001,6 +1004,7 @@ fn erase_brackets(
     x: i16,
     y: i16,
 ) -> Result<(), Box<dyn std::error::Error>> {
+    let x = x.max(1);
     stdout
         .queue(cursor::MoveTo(x as u16 - 1, y as u16))?
         .queue(style::Print(' '))?
@@ -1334,17 +1338,25 @@ pub fn main_inner() -> Result<(), Box<dyn std::error::Error>> {
         }
 
         if let Some((x, y)) = previous_hovered {
-            erase_brackets(&mut stdout, x - scroll_x, y - scroll_y)?;
+            let sx = x - scroll_x;
+            let sy = y - scroll_y;
+            if sx >= 1 && (sx as u16) < term_w && sy >= 0 && (sy as u16) < term_h.saturating_sub(2) {
+                erase_brackets(&mut stdout, sx, sy)?;
+            }
         }
 
         if let Some((x, y)) = state.hovered {
-            draw_brackets(
-                &mut stdout,
-                x - scroll_x,
-                y - scroll_y,
-                ClickedStyle::Hovered,
-                &state.prefs,
-            )?;
+            let sx = x - scroll_x;
+            let sy = y - scroll_y;
+            if sx >= 1 && (sx as u16) < term_w && sy >= 0 && (sy as u16) < term_h.saturating_sub(2) {
+                draw_brackets(
+                    &mut stdout,
+                    sx,
+                    sy,
+                    ClickedStyle::Hovered,
+                    &state.prefs,
+                )?;
+            }
         }
 
         let clicked_stickers = state.clicked_stickers();
@@ -1428,12 +1440,16 @@ pub fn main_inner() -> Result<(), Box<dyn std::error::Error>> {
         }
 
         for (x, y) in erase_locs {
-            erase_brackets(&mut stdout, x, y)?;
+            if x >= 1 && (x as u16) < term_w && y >= 0 && (y as u16) < term_h.saturating_sub(2) {
+                erase_brackets(&mut stdout, x, y)?;
+            }
         }
 
         for style in CLICKED_STYLES {
             for (x, y) in clicked_locs.get(style).expect("contains") {
-                draw_brackets(&mut stdout, *x, *y, *style, &state.prefs)?;
+                if *x >= 1 && (*x as u16) < term_w && *y >= 0 && (*y as u16) < term_h.saturating_sub(2) {
+                    draw_brackets(&mut stdout, *x, *y, *style, &state.prefs)?;
+                }
             }
         }
 

--- a/src/state.rs
+++ b/src/state.rs
@@ -30,28 +30,6 @@ const FRAME_LENGTH: Duration = Duration::from_millis(1000 / 30);
 
 static CTRL_C_PRESSED: AtomicBool = AtomicBool::new(false);
 
-#[cfg(windows)]
-unsafe extern "system" {
-    fn SetConsoleCtrlHandler(
-        handler: Option<unsafe extern "system" fn(u32) -> i32>,
-        add: i32,
-    ) -> i32;
-}
-
-#[cfg(windows)]
-unsafe extern "system" fn console_ctrl_handler(ctrl_type: u32) -> i32 {
-    const CTRL_C_EVENT: u32 = 0;
-    const CTRL_BREAK_EVENT: u32 = 1;
-    if ctrl_type == CTRL_C_EVENT || ctrl_type == CTRL_BREAK_EVENT {
-        if CTRL_C_PRESSED.swap(true, Ordering::SeqCst) {
-            return 0; // second Ctrl+C — let default handler terminate
-        }
-        1
-    } else {
-        0 // pass through for close/logoff events
-    }
-}
-
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub enum TurnLayer {
     Layer(i16),
@@ -942,10 +920,11 @@ pub fn main_inner() -> Result<(), Box<dyn std::error::Error>> {
 
     let stdout_manager = StdoutManager;
 
-    #[cfg(windows)]
-    unsafe {
-        SetConsoleCtrlHandler(Some(console_ctrl_handler), 1);
-    }
+    ctrlc::set_handler(move || {
+        if CTRL_C_PRESSED.swap(true, Ordering::SeqCst) {
+            std::process::exit(0); // second Ctrl+C — terminate immediately
+        }
+    })?;
 
     const SCROLL_STEP_WHEEL: i16 = 3;
 

--- a/src/state.rs
+++ b/src/state.rs
@@ -171,6 +171,13 @@ pub struct AppState {
     pub clicked: Vec<Vec<i16>>,
     pub filename: PathBuf,
     pub prefs: Prefs,
+    pub rev_stack: Vec<RevEntry>,
+}
+
+#[derive(Debug, Clone)]
+pub struct RevEntry {
+    pub start: usize,
+    pub end: Option<usize>,
 }
 
 #[derive(Serialize, Deserialize)]
@@ -235,6 +242,7 @@ impl AppState {
             clicked: Vec::new(),
             filename: Self::new_filename(),
             prefs,
+            rev_stack: vec![],
         })
     }
 
@@ -334,12 +342,14 @@ impl AppState {
                     self.scramble = self.puzzle.clone();
                     self.undo_history = vec![];
                     self.redo_history = vec![];
+                    self.rev_stack.clear();
                 } else if ch == self.prefs.global_keys.reset {
                     self.puzzle = Puzzle::make_solved(self.puzzle.n, self.puzzle.d);
                     self.message = Some("puzzle reset".to_string());
                     self.scramble = self.puzzle.clone();
                     self.undo_history = vec![];
                     self.redo_history = vec![];
+                    self.rev_stack.clear();
                 }
                 self.damage_counter = None;
             }
@@ -377,6 +387,7 @@ impl AppState {
                         }
                     } else if c == self.prefs.global_keys.undo {
                         self.flush_modes();
+                        self.rev_stack.clear();
                         let undid = self.undo_history.pop();
                         match undid {
                             None => {
@@ -389,6 +400,7 @@ impl AppState {
                         }
                     } else if c == self.prefs.global_keys.redo {
                         self.flush_modes();
+                        self.rev_stack.clear();
                         let redid = self.redo_history.pop();
                         match redid {
                             None => {
@@ -799,6 +811,80 @@ impl AppState {
         }
         out
     }
+
+    fn rev_start(&mut self) {
+        self.rev_stack.push(RevEntry {
+            start: self.undo_history.len(),
+            end: None,
+        });
+    }
+
+    fn rev_stop(&mut self) {
+        if let Some(top) = self.rev_stack.last() {
+            if top.end.is_some() || self.undo_history.len() <= top.start {
+                self.rev_stack.pop();
+            } else {
+                self.rev_stack.last_mut().unwrap().end = Some(self.undo_history.len());
+            }
+        }
+    }
+
+    fn apply_reverse(&mut self, from: usize, to: usize) {
+        let turns: Vec<Turn> = self.undo_history[from..to]
+            .iter()
+            .rev()
+            .cloned()
+            .collect();
+        for turn in turns {
+            let inverse = turn.inverse();
+            self.puzzle.turn(inverse.clone());
+            self.undo_history.push(inverse);
+        }
+    }
+
+    fn rev_unwind(&mut self) {
+        if let Some(entry) = self.rev_stack.pop() {
+            if let Some(r) = entry.end {
+                if self.undo_history.len() >= r {
+                    self.apply_reverse(entry.start, r);
+                }
+            }
+        }
+    }
+
+    fn rev_commutator(&mut self) {
+        if let Some(entry) = self.rev_stack.pop() {
+            if let Some(r) = entry.end {
+                let p = self.undo_history.len();
+                if p >= r {
+                    self.apply_reverse(entry.start, r);
+                    self.apply_reverse(r, p);
+                }
+            }
+        }
+    }
+
+    fn rev_stack_display(&self) -> String {
+        let mut s = String::new();
+        let mut pos = 0usize;
+        for entry in &self.rev_stack {
+            if entry.start > pos {
+                s.push_str(&(entry.start - pos).to_string());
+            }
+            s.push('[');
+            if let Some(end) = entry.end {
+                s.push_str(&(end - entry.start).to_string());
+                s.push(']');
+                pos = end;
+            } else {
+                pos = entry.start;
+            }
+        }
+        if pos < self.undo_history.len() {
+            s.push_str(&(self.undo_history.len() - pos).to_string());
+        }
+        s
+    }
 }
 
 fn draw_brackets(
@@ -938,6 +1024,7 @@ pub fn main_inner() -> Result<(), Box<dyn std::error::Error>> {
 
     'event: loop {
         let previous_message = state.get_message();
+        let previous_rev_stack = state.rev_stack_display();
         let previous_hovered = state.hovered;
         let previous_clicked_stickers = state.clicked_stickers();
         let mut just_resized = false;
@@ -956,6 +1043,10 @@ pub fn main_inner() -> Result<(), Box<dyn std::error::Error>> {
                     KeyCode::Char('c') if modifiers.contains(KeyModifiers::CONTROL) => {
                         break 'event;
                     }
+                    KeyCode::F(1) => state.rev_start(),
+                    KeyCode::F(2) => state.rev_stop(),
+                    KeyCode::F(3) => state.rev_unwind(),
+                    KeyCode::F(4) => state.rev_commutator(),
                     KeyCode::Char(c) => {
                         state.process_key(c);
                     }
@@ -972,15 +1063,15 @@ pub fn main_inner() -> Result<(), Box<dyn std::error::Error>> {
                         state.process_key(BACKSPACE_CODE);
                     }
                     KeyCode::Up => {
-                        let step = (term_h.saturating_sub(1) as i16 * 3 / 4).max(1);
+                        let step = (term_h.saturating_sub(2) as i16 * 3 / 4).max(1);
                         scroll_y = (scroll_y - step).max(0);
                     }
                     KeyCode::Down => {
-                        let step = (term_h.saturating_sub(1) as i16 * 3 / 4).max(1);
+                        let step = (term_h.saturating_sub(2) as i16 * 3 / 4).max(1);
                         scroll_y = (scroll_y + step).min(
                             layout
                                 .height
-                                .saturating_sub(term_h.saturating_sub(1))
+                                .saturating_sub(term_h.saturating_sub(2))
                                 as i16,
                         );
                     }
@@ -1019,7 +1110,7 @@ pub fn main_inner() -> Result<(), Box<dyn std::error::Error>> {
                                 scroll_y = (scroll_y + SCROLL_STEP_WHEEL).min(
                                     layout
                                         .height
-                                        .saturating_sub(term_h.saturating_sub(1))
+                                        .saturating_sub(term_h.saturating_sub(2))
                                         as i16,
                                 );
                             }
@@ -1044,7 +1135,7 @@ pub fn main_inner() -> Result<(), Box<dyn std::error::Error>> {
                                     0,
                                     layout
                                         .height
-                                        .saturating_sub(term_h.saturating_sub(1))
+                                        .saturating_sub(term_h.saturating_sub(2))
                                         as i16,
                                 );
                             }
@@ -1103,7 +1194,7 @@ pub fn main_inner() -> Result<(), Box<dyn std::error::Error>> {
                     scroll_y = scroll_y.min(
                         layout
                             .height
-                            .saturating_sub(term_h.saturating_sub(1))
+                            .saturating_sub(term_h.saturating_sub(2))
                             as i16,
                     );
                     stdout.execute(terminal::Clear(terminal::ClearType::All))?;
@@ -1123,12 +1214,24 @@ pub fn main_inner() -> Result<(), Box<dyn std::error::Error>> {
         }
 
         let message = state.get_message();
+        let rev_stack_display = state.rev_stack_display();
 
         if just_resized {
             stdout
-                .queue(cursor::MoveTo(0, term_h.saturating_sub(1)))?
+                .queue(cursor::MoveTo(0, term_h.saturating_sub(2)))?
                 .queue(terminal::Clear(terminal::ClearType::All))?
                 .flush()?;
+        }
+        if previous_rev_stack != rev_stack_display || scrolled || just_resized {
+            stdout
+                .queue(cursor::MoveTo(0, term_h.saturating_sub(2)))?
+                .queue(terminal::Clear(terminal::ClearType::CurrentLine))?;
+            if !rev_stack_display.is_empty() {
+                stdout.queue(style::Print(&format!(
+                    "RevStack: {}",
+                    rev_stack_display
+                )))?;
+            }
         }
         if previous_message != message || scrolled || just_resized {
             stdout
@@ -1164,7 +1267,7 @@ pub fn main_inner() -> Result<(), Box<dyn std::error::Error>> {
             if screen_x < 0
                 || screen_x >= term_w as i16
                 || screen_y < 0
-                || screen_y >= term_h.saturating_sub(1) as i16
+                || screen_y >= term_h.saturating_sub(2) as i16
             {
                 continue;
             }
@@ -1247,7 +1350,7 @@ pub fn main_inner() -> Result<(), Box<dyn std::error::Error>> {
             if screen_x < 0
                 || screen_x >= term_w as i16
                 || screen_y < 0
-                || screen_y >= term_h.saturating_sub(1) as i16
+                || screen_y >= term_h.saturating_sub(2) as i16
             {
                 continue;
             }

--- a/src/state.rs
+++ b/src/state.rs
@@ -1176,19 +1176,35 @@ pub fn main_inner() -> Result<(), Box<dyn std::error::Error>> {
                         state.process_key(BACKSPACE_CODE);
                     }
                     KeyCode::Up => {
-                        let step = (term_h.saturating_sub(2) as i16 * 3 / 4).max(1);
+                        let step = if modifiers.contains(KeyModifiers::CONTROL) {
+                            1
+                        } else {
+                            (term_h.saturating_sub(2) as i16 * 3 / 4).max(1)
+                        };
                         scroll_y = (scroll_y - step).max(0);
                     }
                     KeyCode::Down => {
-                        let step = (term_h.saturating_sub(2) as i16 * 3 / 4).max(1);
+                        let step = if modifiers.contains(KeyModifiers::CONTROL) {
+                            1
+                        } else {
+                            (term_h.saturating_sub(2) as i16 * 3 / 4).max(1)
+                        };
                         scroll_y = (scroll_y + step).min(scroll_max_y);
                     }
                     KeyCode::Left => {
-                        let step = (term_w as i16 * 3 / 4).max(1);
+                        let step = if modifiers.contains(KeyModifiers::CONTROL) {
+                            1
+                        } else {
+                            (term_w as i16 * 3 / 4).max(1)
+                        };
                         scroll_x = (scroll_x - step).max(0);
                     }
                     KeyCode::Right => {
-                        let step = (term_w as i16 * 3 / 4).max(1);
+                        let step = if modifiers.contains(KeyModifiers::CONTROL) {
+                            1
+                        } else {
+                            (term_w as i16 * 3 / 4).max(1)
+                        };
                         scroll_x = (scroll_x + step).min(scroll_max_x);
                     }
                     _ => (),

--- a/src/state.rs
+++ b/src/state.rs
@@ -106,11 +106,11 @@ pub enum KeybindSet {
 }
 
 impl KeybindSet {
-    fn valid(&self, n: i16) -> bool {
+    fn valid(&self, _n: i16) -> bool {
         match self {
             Self::ThreeKey => true,
             Self::ThreeKeyStrict => true,
-            Self::FixedKey => n >= 3,
+            Self::FixedKey => true,
             //Self::XyzKey => n == 4,
         }
     }
@@ -339,14 +339,10 @@ impl AppState {
             return true;
         }
         if c == self.prefs.global_keys.axis_mode {
-            if self.puzzle.d > 6 {
-                self.message = Some("not enough room for side keybinds".to_string());
-            } else {
-                self.flush_modes();
-                self.keybind_axial = self.keybind_axial.next();
-                self.message =
-                    Some(format!("set axis mode to {}", self.keybind_axial.name()));
-            }
+            self.flush_modes();
+            self.keybind_axial = self.keybind_axial.next();
+            self.message =
+                Some(format!("set axis mode to {}", self.keybind_axial.name()));
             return true;
         }
         if c == self.prefs.global_keys.undo {
@@ -406,7 +402,14 @@ impl AppState {
             self.current_turn.layer = Some(TurnLayer::Layer(s as i16));
             return true;
         }
-        if self.current_turn.layer != Some(TurnLayer::WholePuzzle)
+        // Side-select guard: normally skipped when WholePuzzle is set (the
+        // key should be an axis key), but FixedKey 3D needs it for x+key.
+        if (self.current_turn.layer != Some(TurnLayer::WholePuzzle)
+                || (self.keybind_set == KeybindSet::FixedKey && self.puzzle.d == 3))
+            // In ThreeKey, a key that is both select and axis should be
+            // processed as an axis when side is already set — skip this
+            // branch. FixedKey 3D has no downstream axis processing, so
+            // exclude it from the guard.
             && !self.awaiting_side_as_axis()
             && let Some(kp) = self.get_side(c)
             && !(self.current_turn.side.is_some()
@@ -416,7 +419,7 @@ impl AppState {
             if ax(kp.axis) as u16 >= self.puzzle.d {
                 return true;
             }
-            if self.current_turn.layer.is_none() || self.current_turn.side.is_some() {
+            if self.current_turn.layer.is_none() {
                 self.flush_modes();
             }
             self.current_turn.side = Some(kp);
@@ -508,14 +511,15 @@ impl AppState {
         }
     }
 
-    // In FixedKey 3D, the turn is handled inline by handle_prefix_keys
-    // when a select key is pressed — a single keypress fully defines the rotation.
-    fn try_fixed_3d(&mut self, _c: char) {}
-
+    // In FixedKey 3D, normal turns are handled inline by handle_prefix_keys.
+    // Whole-puzzle (x) rotations are routed to try_three_key for axis input.
     // Process an axis key in FixedKey mode for d > 3.
     // Accumulates axes in `fixed` until d-3 (or d-2 for whole-puzzle) are collected,
     // then resolves the rotation plane and direction via permutation parity.
     fn try_fixed_key(&mut self, c: char) {
+        if self.puzzle.d < 3 {
+            return;
+        }
         let Some(kp) = self.get_axis_key(c) else { return };
         if ax(kp.axis) as u16 >= self.puzzle.d {
             return;
@@ -670,9 +674,7 @@ impl AppState {
                         KeybindSet::ThreeKey | KeybindSet::ThreeKeyStrict => {
                             self.try_three_key(c);
                         }
-                        KeybindSet::FixedKey if self.puzzle.d == 3 => {
-                            self.try_fixed_3d(c);
-                        }
+                        KeybindSet::FixedKey if self.puzzle.d == 3 => {}
                         KeybindSet::FixedKey => {
                             self.try_fixed_key(c);
                         }

--- a/src/state.rs
+++ b/src/state.rs
@@ -1,7 +1,6 @@
 use crate::filters;
 use crate::filters::Filter;
 use crate::layout::Layout;
-use crate::prefs;
 use crate::prefs::Prefs;
 use crate::prefs::BACKSPACE_CODE;
 use crate::prefs::ESCAPE_CODE;
@@ -871,13 +870,11 @@ struct Args {
 
 pub fn main_inner() -> Result<(), Box<dyn std::error::Error>> {
     let args = Args::parse();
-    let prefs: Prefs = {
-        let path = args
-            .prefs
-            .unwrap_or(PathBuf::from(prefs::DEFAULT_FILE_PATH_STR));
+    let prefs: Prefs = if let Some(path) = args.prefs {
         let file = File::open(path)?;
-        let reader = BufReader::new(file);
-        serde_json::from_reader(reader)?
+        serde_json::from_reader(BufReader::new(file))?
+    } else {
+        Prefs::load_default()?
     };
 
     let mut state;

--- a/src/state.rs
+++ b/src/state.rs
@@ -329,6 +329,8 @@ impl AppState {
         self.keybind_set == KeybindSet::ThreeKeyStrict && self.current_turn.side.is_some()
     }
 
+    // Handle global mode keys, layer select, side select, and rotate (x).
+    // Returns true if the key was consumed and should not be processed further.
     fn handle_prefix_keys(&mut self, c: char) -> bool {
         if c == self.prefs.global_keys.keybind_mode {
             self.flush_modes();
@@ -427,6 +429,9 @@ impl AppState {
         false
     }
 
+    // Process an axis key in ThreeKey or ThreeKeyStrict mode.
+    // The first axis key sets `from`; the second completes a turn via perform_turn.
+    // Whole-puzzle (x) rotations swap from/to when axis keys have opposite signs.
     fn try_three_key(&mut self, c: char) {
         let strict = self.keybind_set == KeybindSet::ThreeKeyStrict;
         let axis = if strict {
@@ -488,6 +493,8 @@ impl AppState {
         }
     }
 
+    // Process a side key in FixedKey mode for 3D puzzles.
+    // A single side key fully defines the rotation (no axis keys needed).
     fn try_fixed_3d(&mut self, c: char) {
         let (axis, flip) =
             if let Some(s) = self.prefs.axes.iter().position(|ax| ax.pos.keys.side == c) {
@@ -526,6 +533,9 @@ impl AppState {
         }
     }
 
+    // Process an axis key in FixedKey mode for d > 3.
+    // Accumulates axes in `fixed` until d-3 (or d-2 for whole-puzzle) are collected,
+    // then resolves the rotation plane and direction via permutation parity.
     fn try_fixed_key(&mut self, c: char) {
         let Some(kp) = self.get_axis_key(c) else { return };
         if ax(kp.axis) as u16 >= self.puzzle.d {
@@ -617,6 +627,9 @@ impl AppState {
         layout
     }
 
+    // Main key dispatch. Handles damage-counter keys (scramble/reset),
+    // global mode keys, then delegates to handle_prefix_keys and the
+    // mode-specific try_* methods for turn input.
     pub fn process_key(&mut self, c: char) {
         self.message = None;
         if c == self.prefs.global_keys.scramble || c == self.prefs.global_keys.reset {
@@ -748,6 +761,9 @@ impl AppState {
         }
     }
 
+    // Look up c as an axis/side key (not a select key). In side mode
+    // negative sides are encoded as bitwise NOT (!s) to distinguish them
+    // from positive sides while preserving the axis index via ax().
     fn get_axis_key(&self, c: char) -> Option<KeyPress> {
         if self.keybind_set == KeybindSet::ThreeKeyStrict {
             return None;
@@ -770,6 +786,9 @@ impl AppState {
         }
     }
 
+    // Execute a puzzle turn. Reads self.current_turn.layer to decide whether
+    // this is a whole-puzzle rotation (PuzzleTurn) or a layer turn (SideTurn).
+    // Returns None if the turn is invalid (e.g. degenerate plane).
     fn perform_turn(&mut self, side: i16, from: i16, to: i16) -> Option<()> {
         let mut layer_min;
         let mut layer_max;
@@ -863,6 +882,8 @@ impl AppState {
         }
     }
 
+    // Collect all sticker positions that should display click brackets.
+    // Includes the clicked piece body and adjacent stickers on each axis.
     fn clicked_stickers(&self) -> HashMap<Vec<i16>, ClickedStyle> {
         let mut out = HashMap::new();
         for clicked in &self.clicked {
@@ -885,6 +906,7 @@ impl AppState {
         out
     }
 
+    // Begin a reversion block — subsequent turns are grouped for F3/F4 undo.
     fn rev_start(&mut self) {
         self.rev_stack.push(RevEntry {
             start: self.undo_history.len(),
@@ -959,6 +981,8 @@ impl AppState {
         s
     }
 
+    // After undo/redo, shift rev-stack indices so they stay valid relative
+    // to the new undo_history length.
     fn rev_stack_adjust(&mut self) {
         let len = self.undo_history.len();
         self.rev_stack.retain_mut(|entry| {
@@ -1063,6 +1087,9 @@ struct Args {
     prefs: Option<PathBuf>,
 }
 
+// Main event loop: set up terminal, poll for input events, render the puzzle
+// each frame. Rendering order is hovered brackets → puzzle points → clicked
+// brackets → keybind hints, so later layers paint over earlier ones.
 pub fn main_inner() -> Result<(), Box<dyn std::error::Error>> {
     let args = Args::parse();
     let prefs: Prefs = if let Some(path) = args.prefs {

--- a/src/state.rs
+++ b/src/state.rs
@@ -409,7 +409,9 @@ impl AppState {
         if self.current_turn.layer != Some(TurnLayer::WholePuzzle)
             && !self.awaiting_side_as_axis()
             && let Some(kp) = self.get_side(c)
-            && !(self.current_turn.side.is_some() && self.get_axis_key(c).is_some())
+            && !(self.current_turn.side.is_some()
+                && self.get_axis_key(c).is_some()
+                && !(self.keybind_set == KeybindSet::FixedKey && self.puzzle.d == 3))
         {
             if ax(kp.axis) as u16 >= self.puzzle.d {
                 return true;

--- a/src/state.rs
+++ b/src/state.rs
@@ -23,9 +23,34 @@ use std::io::BufReader;
 use std::io::BufWriter;
 use std::io::{self, Write};
 use std::path::PathBuf;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::{Duration, Instant};
 
 const FRAME_LENGTH: Duration = Duration::from_millis(1000 / 30);
+
+static CTRL_C_PRESSED: AtomicBool = AtomicBool::new(false);
+
+#[cfg(windows)]
+unsafe extern "system" {
+    fn SetConsoleCtrlHandler(
+        handler: Option<unsafe extern "system" fn(u32) -> i32>,
+        add: i32,
+    ) -> i32;
+}
+
+#[cfg(windows)]
+unsafe extern "system" fn console_ctrl_handler(ctrl_type: u32) -> i32 {
+    const CTRL_C_EVENT: u32 = 0;
+    const CTRL_BREAK_EVENT: u32 = 1;
+    if ctrl_type == CTRL_C_EVENT || ctrl_type == CTRL_BREAK_EVENT {
+        if CTRL_C_PRESSED.swap(true, Ordering::SeqCst) {
+            return 0; // second Ctrl+C — let default handler terminate
+        }
+        1
+    } else {
+        0 // pass through for close/logoff events
+    }
+}
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub enum TurnLayer {
@@ -301,8 +326,8 @@ impl AppState {
             })
     }
 
-    pub fn make_layout(&self, compact: bool, vertical: bool) -> Layout {
-        Layout::make_layout(self.puzzle.n, self.puzzle.d, compact, vertical).move_right(1)
+    pub fn make_layout(&self, semi_compact: bool, compact: bool, vertical: bool) -> Layout {
+        Layout::make_layout(self.puzzle.n, self.puzzle.d, semi_compact, compact, vertical).move_right(1)
     }
 
     pub fn process_key(&mut self, c: char) {
@@ -830,7 +855,8 @@ impl Drop for StdoutManager {
         let mut stdout = io::stdout();
         let _ = stdout.execute(cursor::Show);
         let _ = stdout.execute(crossterm::event::DisableMouseCapture);
-        let _ = terminal::disable_raw_mode(); // does this help?
+        let _ = terminal::disable_raw_mode();
+        let _ = stdout.execute(terminal::LeaveAlternateScreen);
     }
 }
 
@@ -843,8 +869,12 @@ struct Args {
     /// Dimension of the puzzle
     d: Option<u16>,
 
-    /// Display in compact mode
-    #[arg(short, long)]
+    /// Display in semi-compact mode (1-char gaps between layers)
+    #[arg(short = 'c')]
+    semi_compact: bool,
+
+    /// Display in compact mode (no gaps between layers)
+    #[arg(long)]
     compact: bool,
 
     /// File that contains the filters for the solve, one per line
@@ -895,7 +925,7 @@ pub fn main_inner() -> Result<(), Box<dyn std::error::Error>> {
             .collect();
     }
 
-    let layout = state.make_layout(args.compact, args.vertical);
+    let layout = state.make_layout(args.semi_compact, args.compact, args.vertical);
     //println!("{:?}", layout.keybind_hints);
     //return Ok(());
 
@@ -906,6 +936,11 @@ pub fn main_inner() -> Result<(), Box<dyn std::error::Error>> {
     stdout.execute(crossterm::event::EnableMouseCapture)?;
 
     let stdout_manager = StdoutManager;
+
+    #[cfg(windows)]
+    unsafe {
+        SetConsoleCtrlHandler(Some(console_ctrl_handler), 1);
+    }
 
     const SCROLL_STEP_WHEEL: i16 = 3;
 
@@ -1078,6 +1113,10 @@ pub fn main_inner() -> Result<(), Box<dyn std::error::Error>> {
                 }
                 _ => (),
             }
+        }
+
+        if CTRL_C_PRESSED.load(Ordering::SeqCst) {
+            break 'event;
         }
 
         if (scroll_x, scroll_y) != scroll_before {

--- a/src/state.rs
+++ b/src/state.rs
@@ -1119,7 +1119,8 @@ pub fn main_inner() -> Result<(), Box<dyn std::error::Error>> {
             break 'event;
         }
 
-        if (scroll_x, scroll_y) != scroll_before {
+        let scrolled = (scroll_x, scroll_y) != scroll_before;
+        if scrolled {
             stdout.execute(terminal::Clear(terminal::ClearType::All))?;
         }
 
@@ -1131,11 +1132,11 @@ pub fn main_inner() -> Result<(), Box<dyn std::error::Error>> {
                 .queue(terminal::Clear(terminal::ClearType::All))?
                 .flush()?;
         }
-        if previous_message != message {
+        if previous_message != message || scrolled || just_resized {
             stdout
                 .queue(cursor::MoveTo(0, term_h.saturating_sub(1)))?
                 .queue(terminal::Clear(terminal::ClearType::CurrentLine))?
-                .queue(style::Print(message))?;
+                .queue(style::Print(&message))?;
         }
 
         if let Some((x, y)) = previous_hovered {

--- a/src/state.rs
+++ b/src/state.rs
@@ -1151,7 +1151,17 @@ pub fn main_inner() -> Result<(), Box<dyn std::error::Error>> {
                     KeyCode::F(3) => state.rev_unwind(),
                     KeyCode::F(4) => state.rev_commutator(),
                     KeyCode::Char(c) => {
-                        state.process_key(c);
+                        if c == state.prefs.global_keys.rev_start {
+                            state.rev_start();
+                        } else if c == state.prefs.global_keys.rev_stop {
+                            state.rev_stop();
+                        } else if c == state.prefs.global_keys.rev_unwind {
+                            state.rev_unwind();
+                        } else if c == state.prefs.global_keys.rev_commutator {
+                            state.rev_commutator();
+                        } else {
+                            state.process_key(c);
+                        }
                     }
                     KeyCode::Tab => {
                         state.process_key('\t');

--- a/src/state.rs
+++ b/src/state.rs
@@ -212,7 +212,8 @@ impl AppState {
 
         if d > prefs.max_dim() {
             return Err(format!(
-                "dimension should be less than or equal to {}",
+                "dimension {} exceeds the {} axes defined in this prefs config",
+                d,
                 prefs.max_dim()
             )
             .into());
@@ -222,13 +223,14 @@ impl AppState {
         }
         if n > prefs.max_layers() {
             return Err(format!(
-                "side should be less than or equal to {}",
+                "layers {} exceeds the {} layer keys defined in this prefs config",
+                n,
                 prefs.max_layers()
             )
             .into());
         }
-        if d < 1 {
-            return Err("side should be greater than 0".into());
+        if n < 1 {
+            return Err("layers should be greater than 0".into());
         }
 
         Ok(Self {
@@ -908,6 +910,7 @@ pub fn main_inner() -> Result<(), Box<dyn std::error::Error>> {
     } else {
         Prefs::load_default()?
     };
+    prefs.validate()?;
 
     let mut state;
     if let Some(log_file) = args.log {

--- a/src/state.rs
+++ b/src/state.rs
@@ -418,6 +418,19 @@ impl AppState {
                 self.flush_modes();
             }
             self.current_turn.side = Some(kp);
+            if self.keybind_set == KeybindSet::FixedKey && self.puzzle.d == 3 {
+                let (from, to) = if kp.axis < 0 {
+                    ((!kp.axis + 2) % 3, (!kp.axis + 1) % 3)
+                } else {
+                    ((kp.axis + 1) % 3, (kp.axis + 2) % 3)
+                };
+                if self.perform_turn(kp.axis, from, to).is_some() {
+                    self.last_turn_keys = self.current_turn.current_keys();
+                } else {
+                    self.alert = self.prefs.alert_frames * 4 - 1;
+                    self.last_turn_keys.clear();
+                }
+            }
             return true;
         }
         if c == self.prefs.global_keys.rotate {
@@ -493,45 +506,9 @@ impl AppState {
         }
     }
 
-    // Process a side key in FixedKey mode for 3D puzzles.
-    // A single side key fully defines the rotation (no axis keys needed).
-    fn try_fixed_3d(&mut self, c: char) {
-        let (axis, flip) =
-            if let Some(s) = self.prefs.axes.iter().position(|ax| ax.pos.keys.side == c) {
-                (s as i16, true)
-            } else if let Some(s) =
-                self.prefs.axes.iter().position(|ax| ax.neg.keys.side == c)
-            {
-                (!(s as i16), true)
-            } else {
-                return;
-            };
-        if ax(axis) as u16 >= self.puzzle.d {
-            return;
-        }
-        if self.current_turn.layer.is_none() || self.current_turn.side.is_some() {
-            self.flush_modes();
-        }
-        self.current_turn.side = Some(KeyPress { ch: c, axis });
-
-        let (from, to) = if flip {
-            if axis < 0 {
-                ((!axis + 1) % 3, (!axis + 2) % 3)
-            } else {
-                ((axis + 2) % 3, (axis + 1) % 3)
-            }
-        } else if axis < 0 {
-            ((!axis + 2) % 3, (!axis + 1) % 3)
-        } else {
-            ((axis + 1) % 3, (axis + 2) % 3)
-        };
-        if self.perform_turn(axis, from, to).is_some() {
-            self.last_turn_keys = self.current_turn.current_keys();
-        } else {
-            self.alert = self.prefs.alert_frames * 4 - 1;
-            self.last_turn_keys.clear();
-        }
-    }
+    // In FixedKey 3D, the turn is handled inline by handle_prefix_keys
+    // when a select key is pressed — a single keypress fully defines the rotation.
+    fn try_fixed_3d(&mut self, _c: char) {}
 
     // Process an axis key in FixedKey mode for d > 3.
     // Accumulates axes in `fixed` until d-3 (or d-2 for whole-puzzle) are collected,

--- a/src/state.rs
+++ b/src/state.rs
@@ -438,7 +438,8 @@ impl AppState {
                         self.flush_modes();
                         self.current_keys.push(c);
                         self.current_turn.layer = Some(TurnLayer::Layer(s as i16));
-                    } else if !self.awaiting_side_as_axis()
+                    } else if self.current_turn.layer != Some(TurnLayer::WholePuzzle)
+                        && !self.awaiting_side_as_axis()
                         && let Some(s) = self.get_side(c)
                         && !(self.current_turn.side.is_some() && self.get_axis_key(c).is_some())
                     {
@@ -452,12 +453,10 @@ impl AppState {
                         self.current_turn.side = Some(s);
                         just_pressed_side = true;
                     } else if c == self.prefs.global_keys.rotate {
-                        if self.keybind_set == KeybindSet::ThreeKey {
-                            self.flush_modes();
-                            just_pressed_side = true;
-                        }
+                        self.flush_modes();
                         self.current_keys.push(c);
                         self.current_turn.layer = Some(TurnLayer::WholePuzzle);
+                        just_pressed_side = true;
                     }
 
                     match self.keybind_set {
@@ -478,7 +477,6 @@ impl AppState {
                                 if ax(s) as u16 >= self.puzzle.d {
                                     return;
                                 }
-                                self.current_keys.push(c);
 
                                 let side = if self.current_turn.side.is_some() {
                                     self.current_turn.side
@@ -489,8 +487,18 @@ impl AppState {
                                 };
 
                                 if let Some(side) = side {
-                                    if let Some(from) = self.current_turn.from {
-                                        let turn_out = self.perform_turn(side, from, s);
+                                    if self.current_turn.from.is_none() {
+                                        self.current_keys = self.base_keys();
+                                    }
+                                    self.current_keys.push(c);
+
+                                    if let Some(from_raw) = self.current_turn.from {
+                                        let (from_norm, to_norm) = if self.current_turn.layer == Some(TurnLayer::WholePuzzle) {
+                                            (ax(from_raw), ax(s))
+                                        } else {
+                                            (from_raw, s)
+                                        };
+                                        let turn_out = self.perform_turn(side, from_norm, to_norm);
 
                                         if turn_out.is_none() {
                                             self.alert = self.prefs.alert_frames * 4 - 1;
@@ -498,10 +506,12 @@ impl AppState {
                                             self.current_keys = self.current_keys
                                                 [..self.current_keys.len() - key_removal]
                                                 .to_string();
+                                        } else {
+                                            self.current_keys = self.canonical_turn_keys(from_raw, s);
                                         }
                                         self.current_turn.from = None;
                                         if strict {
-                                            self.current_turn.side = None;
+                                            self.current_turn = Default::default();
                                         }
                                     } else {
                                         self.current_turn.from = Some(s);
@@ -547,17 +557,17 @@ impl AppState {
 
                             if let (Some(side), true) = (self.current_turn.side, just_pressed_side)
                             {
-                                if flip {
+                                let _turn_out = if flip {
                                     if side < 0 {
-                                        self.perform_turn(side, (!side + 1) % 3, (!side + 2) % 3);
+                                        self.perform_turn(side, (!side + 1) % 3, (!side + 2) % 3)
                                     } else {
-                                        self.perform_turn(side, (side + 2) % 3, (side + 1) % 3);
+                                        self.perform_turn(side, (side + 2) % 3, (side + 1) % 3)
                                     }
                                 } else if side < 0 {
-                                    self.perform_turn(side, (!side + 2) % 3, (!side + 1) % 3);
+                                    self.perform_turn(side, (!side + 2) % 3, (!side + 1) % 3)
                                 } else {
-                                    self.perform_turn(side, (side + 1) % 3, (side + 2) % 3);
-                                }
+                                    self.perform_turn(side, (side + 1) % 3, (side + 2) % 3)
+                                };
                             }
                         }
                         KeybindSet::FixedKey => {
@@ -568,13 +578,34 @@ impl AppState {
                                 if ax(s) as u16 >= self.puzzle.d {
                                     return;
                                 }
+                                if self.current_turn.fixed.is_empty() {
+                                    self.current_keys = self.base_keys();
+                                }
                                 self.current_keys.push(c);
                                 self.current_turn.fixed.push(s);
 
-                                if let Some(side) = self.current_turn.side {
-                                    if self.current_turn.fixed.len() == self.puzzle.d as usize - 3 {
+                                let whole_puzzle =
+                                    self.current_turn.layer == Some(TurnLayer::WholePuzzle);
+                                let required_fixed = if whole_puzzle {
+                                    self.puzzle.d as usize - 2
+                                } else {
+                                    self.puzzle.d as usize - 3
+                                };
+
+                                let side = if whole_puzzle {
+                                    None
+                                } else {
+                                    self.current_turn.side
+                                };
+
+                                if side.is_some() || whole_puzzle {
+                                    if self.current_turn.fixed.len() == required_fixed {
                                         let mut sign = true;
-                                        let mut axes = vec![side];
+                                        let mut axes = if let Some(side) = side {
+                                            vec![side]
+                                        } else {
+                                            vec![]
+                                        };
                                         axes.extend(self.current_turn.fixed.iter().cloned());
 
                                         for axis in &mut axes {
@@ -583,7 +614,6 @@ impl AppState {
                                                 *axis = !*axis;
                                             }
                                         }
-                                        //self.message = format!("{:?}", axes).into();
 
                                         for axis in 0..self.puzzle.d as i16 {
                                             if !axes.contains(&axis) {
@@ -611,7 +641,11 @@ impl AppState {
                                             if !sign {
                                                 std::mem::swap(&mut from, &mut to);
                                             }
-                                            self.perform_turn(side, from, to)
+                                            self.perform_turn(
+                                                side.unwrap_or(0),
+                                                from,
+                                                to,
+                                            )
                                         });
 
                                         if turn_out.is_none() {
@@ -704,6 +738,62 @@ impl AppState {
             }),
         }
         .map(|s| s as i16)
+    }
+
+    fn base_keys(&self) -> String {
+        let mut s = String::new();
+        if let Some(TurnLayer::Layer(l)) = self.current_turn.layer {
+            if let Some(&ch) = self.prefs.global_keys.layers.get(l as usize) {
+                s.push(ch);
+            }
+        } else if self.current_turn.layer == Some(TurnLayer::WholePuzzle) {
+            s.push(self.prefs.global_keys.rotate);
+            return s;
+        }
+        if let Some(side) = self.current_turn.side {
+            if side >= 0 {
+                if let Some(axis) = self.prefs.axes.get(side as usize) {
+                    s.push(axis.pos.keys.select);
+                }
+            } else if let Some(axis) = self.prefs.axes.get((!side) as usize) {
+                s.push(axis.neg.keys.select);
+            }
+        }
+        s
+    }
+
+    fn axis_key_char(&self, axis: i16) -> Option<char> {
+        if self.keybind_set == KeybindSet::ThreeKeyStrict {
+            if axis >= 0 {
+                self.prefs.axes.get(axis as usize).map(|ax| ax.pos.keys.select)
+            } else {
+                self.prefs.axes.get((!axis) as usize).map(|ax| ax.neg.keys.select)
+            }
+        } else {
+            match self.keybind_axial {
+                KeybindAxial::Axial => {
+                    self.prefs.axes.get(ax(axis) as usize).map(|ax| ax.axis_key)
+                }
+                KeybindAxial::Side => {
+                    if axis >= 0 {
+                        self.prefs.axes.get(axis as usize).map(|ax| ax.pos.keys.side)
+                    } else {
+                        self.prefs.axes.get((!axis) as usize).map(|ax| ax.neg.keys.side)
+                    }
+                }
+            }
+        }
+    }
+
+    fn canonical_turn_keys(&self, from: i16, to: i16) -> String {
+        let mut s = self.base_keys();
+        if let Some(ch) = self.axis_key_char(from) {
+            s.push(ch);
+        }
+        if let Some(ch) = self.axis_key_char(to) {
+            s.push(ch);
+        }
+        s
     }
 
     fn perform_turn(&mut self, side: i16, from: i16, to: i16) -> Option<()> {
@@ -1383,8 +1473,11 @@ pub fn main_inner() -> Result<(), Box<dyn std::error::Error>> {
             let ch;
             let color;
             if let Some(side) = side {
-                ch = if state.current_turn.side.is_none()
-                    || (state.keybind_set == KeybindSet::FixedKey && state.puzzle.d == 3)
+                ch = if (state.current_turn.side.is_none()
+                        && state.current_turn.layer != Some(TurnLayer::WholePuzzle))
+                    || (state.keybind_set == KeybindSet::FixedKey
+                        && state.puzzle.d == 3
+                        && state.current_turn.layer != Some(TurnLayer::WholePuzzle))
                     || state.keybind_set == KeybindSet::ThreeKeyStrict
                 {
                     if *side >= 0 {

--- a/src/state.rs
+++ b/src/state.rs
@@ -36,12 +36,42 @@ pub enum TurnLayer {
     WholePuzzle,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct KeyPress {
+    pub ch: char,
+    pub axis: i16,
+}
+
+#[derive(Debug, Clone, Default)]
 pub struct TurnBuild {
     pub layer: Option<TurnLayer>,
-    pub side: Option<i16>,
-    pub from: Option<i16>,
-    pub fixed: Vec<i16>,
+    pub layer_char: Option<char>,
+    pub side: Option<KeyPress>,
+    pub from: Option<KeyPress>,
+    pub fixed: Vec<KeyPress>,
+}
+
+impl TurnBuild {
+    fn current_keys(&self) -> String {
+        let mut s = String::new();
+        if let Some(ch) = self.layer_char {
+            s.push(ch);
+        }
+        if let Some(kp) = &self.side {
+            s.push(kp.ch);
+        }
+        if let Some(kp) = &self.from {
+            s.push(kp.ch);
+        }
+        for kp in &self.fixed {
+            s.push(kp.ch);
+        }
+        s
+    }
+
+    fn clear(&mut self) {
+        *self = Default::default();
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
@@ -151,7 +181,7 @@ pub struct AppState {
     pub puzzle: Puzzle,
     pub scramble: Puzzle,
     pub mode: AppMode,
-    pub current_keys: String,
+    pub last_turn_keys: String,
     pub current_turn: TurnBuild,
     pub alert: u8,
     pub damage_counter: Option<(char, u8)>,
@@ -222,7 +252,7 @@ impl AppState {
             puzzle: Puzzle::make_solved(n, d),
             scramble: Puzzle::make_solved(n, d),
             mode: Default::default(),
-            current_keys: "".to_string(),
+            last_turn_keys: String::new(),
             current_turn: Default::default(),
             alert: Default::default(),
             damage_counter: Default::default(),
@@ -289,8 +319,8 @@ impl AppState {
     }
 
     fn flush_modes(&mut self) {
-        self.current_keys = "".to_string();
-        self.current_turn = Default::default();
+        self.current_turn.clear();
+        self.last_turn_keys.clear();
         self.live_filter_string = Default::default();
     }
 
@@ -299,18 +329,285 @@ impl AppState {
         self.keybind_set == KeybindSet::ThreeKeyStrict && self.current_turn.side.is_some()
     }
 
-    fn get_side(&self, c: char) -> Option<i16> {
+    fn handle_prefix_keys(&mut self, c: char) -> bool {
+        if c == self.prefs.global_keys.keybind_mode {
+            self.flush_modes();
+            self.keybind_set = self.keybind_set.next(self.puzzle.n);
+            self.message = Some(format!("set keybinds to {}", self.keybind_set.name()));
+            return true;
+        }
+        if c == self.prefs.global_keys.axis_mode {
+            if self.puzzle.d > 6 {
+                self.message = Some("not enough room for side keybinds".to_string());
+            } else {
+                self.flush_modes();
+                self.keybind_axial = self.keybind_axial.next();
+                self.message =
+                    Some(format!("set axis mode to {}", self.keybind_axial.name()));
+            }
+            return true;
+        }
+        if c == self.prefs.global_keys.undo {
+            self.flush_modes();
+            let undid = self.undo_history.pop();
+            match undid {
+                None => self.message = Some("nothing to undo".to_string()),
+                Some(undid) => {
+                    self.puzzle.turn(undid.inverse());
+                    self.redo_history.push(undid);
+                    self.rev_stack_adjust();
+                }
+            }
+            return true;
+        }
+        if c == self.prefs.global_keys.redo {
+            self.flush_modes();
+            let redid = self.redo_history.pop();
+            match redid {
+                None => self.message = Some("nothing to redo".to_string()),
+                Some(redid) => {
+                    self.puzzle.turn(redid.clone());
+                    self.undo_history.push(redid);
+                    self.rev_stack_adjust();
+                }
+            }
+            return true;
+        }
+        if c == self.prefs.global_keys.next_filter {
+            if self.filters.is_empty() {
+                self.message = Some("no filters loaded".to_string());
+            } else {
+                self.flush_modes();
+                self.filter_ind += 1;
+                self.use_live_filter = false;
+                self.message = Some("next filter".to_string());
+            }
+            return true;
+        }
+        if c == self.prefs.global_keys.prev_filter {
+            if self.filters.is_empty() {
+                self.message = Some("no filters loaded".to_string());
+            } else {
+                self.flush_modes();
+                self.filter_ind -= 1;
+                self.use_live_filter = false;
+                self.message = Some("previous filter".to_string());
+            }
+            return true;
+        }
+        if let Some(s) = self.prefs.global_keys.layers.iter().position(|ch| ch == &c) {
+            if s as i16 >= self.puzzle.n {
+                return true;
+            }
+            self.flush_modes();
+            self.current_turn.layer_char = Some(c);
+            self.current_turn.layer = Some(TurnLayer::Layer(s as i16));
+            return true;
+        }
+        if self.current_turn.layer != Some(TurnLayer::WholePuzzle)
+            && !self.awaiting_side_as_axis()
+            && let Some(kp) = self.get_side(c)
+            && !(self.current_turn.side.is_some() && self.get_axis_key(c).is_some())
+        {
+            if ax(kp.axis) as u16 >= self.puzzle.d {
+                return true;
+            }
+            if self.current_turn.layer.is_none() || self.current_turn.side.is_some() {
+                self.flush_modes();
+            }
+            self.current_turn.side = Some(kp);
+            return true;
+        }
+        if c == self.prefs.global_keys.rotate {
+            self.flush_modes();
+            self.current_turn.layer_char = Some(c);
+            self.current_turn.layer = Some(TurnLayer::WholePuzzle);
+            return true;
+        }
+        false
+    }
+
+    fn try_three_key(&mut self, c: char) {
+        let strict = self.keybind_set == KeybindSet::ThreeKeyStrict;
+        let axis = if strict {
+            self.get_side(c)
+        } else {
+            self.get_axis_key(c)
+        };
+        let Some(kp) = axis else { return };
+
+        if !(self.current_turn.side.is_some()
+            || self.current_turn.layer == Some(TurnLayer::WholePuzzle))
+        {
+            return;
+        }
+        if ax(kp.axis) as u16 >= self.puzzle.d {
+            return;
+        }
+
+        let side_axis = if let Some(side_kp) = self.current_turn.side {
+            side_kp.axis
+        } else if self.current_turn.layer == Some(TurnLayer::WholePuzzle) {
+            0
+        } else {
+            return;
+        };
+
+        if self.current_turn.from.is_none() {
+            self.last_turn_keys.clear();
+        }
+
+        if let Some(from_kp) = self.current_turn.from {
+            let (from_norm, to_norm) =
+                if self.current_turn.layer == Some(TurnLayer::WholePuzzle) {
+                    let f = ax(from_kp.axis);
+                    let t = ax(kp.axis);
+                    if (from_kp.axis < 0) != (kp.axis < 0) {
+                        (t, f)
+                    } else {
+                        (f, t)
+                    }
+                } else {
+                    (from_kp.axis, kp.axis)
+                };
+            // perform_turn must be called BEFORE clearing any state
+            if self.perform_turn(side_axis, from_norm, to_norm).is_some() {
+                let mut keys = self.current_turn.current_keys();
+                keys.push(kp.ch);
+                self.last_turn_keys = keys;
+            } else {
+                self.alert = self.prefs.alert_frames * 4 - 1;
+                self.last_turn_keys.clear();
+            }
+            self.current_turn.from = None;
+            if strict {
+                self.current_turn.clear();
+            }
+        } else {
+            self.current_turn.from = Some(kp);
+        }
+    }
+
+    fn try_fixed_3d(&mut self, c: char) {
+        let (axis, flip) =
+            if let Some(s) = self.prefs.axes.iter().position(|ax| ax.pos.keys.side == c) {
+                (s as i16, true)
+            } else if let Some(s) =
+                self.prefs.axes.iter().position(|ax| ax.neg.keys.side == c)
+            {
+                (!(s as i16), true)
+            } else {
+                return;
+            };
+        if ax(axis) as u16 >= self.puzzle.d {
+            return;
+        }
+        if self.current_turn.layer.is_none() || self.current_turn.side.is_some() {
+            self.flush_modes();
+        }
+        self.current_turn.side = Some(KeyPress { ch: c, axis });
+
+        let (from, to) = if flip {
+            if axis < 0 {
+                ((!axis + 1) % 3, (!axis + 2) % 3)
+            } else {
+                ((axis + 2) % 3, (axis + 1) % 3)
+            }
+        } else if axis < 0 {
+            ((!axis + 2) % 3, (!axis + 1) % 3)
+        } else {
+            ((axis + 1) % 3, (axis + 2) % 3)
+        };
+        if self.perform_turn(axis, from, to).is_some() {
+            self.last_turn_keys = self.current_turn.current_keys();
+        } else {
+            self.alert = self.prefs.alert_frames * 4 - 1;
+            self.last_turn_keys.clear();
+        }
+    }
+
+    fn try_fixed_key(&mut self, c: char) {
+        let Some(kp) = self.get_axis_key(c) else { return };
+        if ax(kp.axis) as u16 >= self.puzzle.d {
+            return;
+        }
+
+        let whole_puzzle = self.current_turn.layer == Some(TurnLayer::WholePuzzle);
+        let required_fixed = if whole_puzzle {
+            self.puzzle.d as usize - 2
+        } else {
+            self.puzzle.d as usize - 3
+        };
+        if !whole_puzzle && self.current_turn.side.is_none() {
+            return;
+        }
+
+        if self.current_turn.fixed.is_empty() {
+            self.last_turn_keys.clear();
+        }
+        self.current_turn.fixed.push(kp);
+        if self.current_turn.fixed.len() != required_fixed {
+            return;
+        }
+
+        let mut sign = true;
+        let mut axes: Vec<i16> = if let Some(side_kp) = &self.current_turn.side {
+            vec![side_kp.axis]
+        } else {
+            vec![]
+        };
+        axes.extend(self.current_turn.fixed.iter().map(|kp| kp.axis));
+        for axis in &mut axes {
+            if *axis < 0 {
+                sign = !sign;
+                *axis = !*axis;
+            }
+        }
+        for axis in 0..self.puzzle.d as i16 {
+            if !axes.contains(&axis) {
+                axes.push(axis);
+            }
+        }
+        if axes.len() > self.puzzle.d as usize {
+            self.alert = self.prefs.alert_frames * 4 - 1;
+            self.current_turn.fixed.clear();
+            return;
+        }
+        for i in 0..axes.len() {
+            for j in 0..i {
+                if i > j {
+                    sign = !sign;
+                }
+            }
+        }
+        let mut from = axes[axes.len() - 2];
+        let mut to = axes[axes.len() - 1];
+        if !sign {
+            std::mem::swap(&mut from, &mut to);
+        }
+        let side_axis = self.current_turn.side.as_ref().map(|kp| kp.axis).unwrap_or(0);
+        // Capture canonical string BEFORE clearing fixed
+        if self.perform_turn(side_axis, from, to).is_some() {
+            self.last_turn_keys = self.current_turn.current_keys();
+        } else {
+            self.alert = self.prefs.alert_frames * 4 - 1;
+            self.last_turn_keys.clear();
+        }
+        self.current_turn.fixed.clear();
+    }
+
+    fn get_side(&self, c: char) -> Option<KeyPress> {
         self.prefs
             .axes
             .iter()
             .position(|ax| ax.pos.keys.select == c)
-            .map(|s| s as i16)
+            .map(|s| KeyPress { ch: c, axis: s as i16 })
             .or_else(|| {
                 self.prefs
                     .axes
                     .iter()
                     .position(|ax| ax.neg.keys.select == c)
-                    .map(|s| !(s as i16))
+                    .map(|s| KeyPress { ch: c, axis: !(s as i16) })
             })
     }
 
@@ -370,301 +667,21 @@ impl AppState {
         } else {
             match self.mode {
                 AppMode::Turn => {
-                    let mut just_pressed_side = false;
-
-                    if c == self.prefs.global_keys.keybind_mode {
-                        self.flush_modes();
-                        self.keybind_set = self.keybind_set.next(self.puzzle.n);
-                        self.message = Some(format!("set keybinds to {}", self.keybind_set.name()))
-                    } else if c == self.prefs.global_keys.axis_mode {
-                        if self.puzzle.d > 6 {
-                            self.message = Some("not enough room for side keybinds".to_string());
-                        } else {
-                            self.flush_modes();
-                            self.keybind_axial = self.keybind_axial.next();
-                            self.message =
-                                Some(format!("set axis mode to {}", self.keybind_axial.name()))
-                        }
-                    } else if c == self.prefs.global_keys.undo {
-                        self.flush_modes();
-                        let undid = self.undo_history.pop();
-                        match undid {
-                            None => {
-                                self.message = Some("nothing to undo".to_string());
-                            }
-                            Some(undid) => {
-                                self.puzzle.turn(undid.inverse());
-                                self.redo_history.push(undid);
-                                self.rev_stack_adjust();
-                            }
-                        }
-                    } else if c == self.prefs.global_keys.redo {
-                        self.flush_modes();
-                        let redid = self.redo_history.pop();
-                        match redid {
-                            None => {
-                                self.message = Some("nothing to redo".to_string());
-                            }
-                            Some(redid) => {
-                                self.puzzle.turn(redid.clone());
-                                self.undo_history.push(redid);
-                                self.rev_stack_adjust();
-                            }
-                        }
-                    } else if c == self.prefs.global_keys.next_filter {
-                        if self.filters.is_empty() {
-                            self.message = Some("no filters loaded".to_string());
-                        } else {
-                            self.flush_modes();
-                            self.filter_ind += 1;
-                            self.use_live_filter = false;
-                            self.message = Some("next filter".to_string());
-                        }
-                    } else if c == self.prefs.global_keys.prev_filter {
-                        if self.filters.is_empty() {
-                            self.message = Some("no filters loaded".to_string());
-                        } else {
-                            self.flush_modes();
-                            self.filter_ind -= 1;
-                            self.use_live_filter = false;
-                            self.message = Some("previous filter".to_string());
-                        }
-                    } else if let Some(s) =
-                        self.prefs.global_keys.layers.iter().position(|ch| ch == &c)
-                    {
-                        if s as i16 >= self.puzzle.n {
-                            return;
-                        }
-                        self.flush_modes();
-                        self.current_keys.push(c);
-                        self.current_turn.layer = Some(TurnLayer::Layer(s as i16));
-                    } else if self.current_turn.layer != Some(TurnLayer::WholePuzzle)
-                        && !self.awaiting_side_as_axis()
-                        && let Some(s) = self.get_side(c)
-                        && !(self.current_turn.side.is_some() && self.get_axis_key(c).is_some())
-                    {
-                        if s.max(!s) as u16 >= self.puzzle.d {
-                            return;
-                        }
-                        if self.current_turn.layer.is_none() || self.current_turn.side.is_some() {
-                            self.flush_modes();
-                        }
-                        self.current_keys.push(c);
-                        self.current_turn.side = Some(s);
-                        just_pressed_side = true;
-                    } else if c == self.prefs.global_keys.rotate {
-                        self.flush_modes();
-                        self.current_keys.push(c);
-                        self.current_turn.layer = Some(TurnLayer::WholePuzzle);
-                        just_pressed_side = true;
+                    let consumed = self.handle_prefix_keys(c);
+                    if consumed {
+                        self.last_turn_keys.clear();
+                        return;
                     }
-
                     match self.keybind_set {
                         KeybindSet::ThreeKey | KeybindSet::ThreeKeyStrict => {
-                            let strict = self.keybind_set == KeybindSet::ThreeKeyStrict;
-
-                            let axis = if strict {
-                                self.get_side(c)
-                            } else {
-                                self.get_axis_key(c)
-                            };
-
-                            if (self.current_turn.side.is_some()
-                                || self.current_turn.layer == Some(TurnLayer::WholePuzzle))
-                                && !just_pressed_side
-                                && let Some(s) = axis
-                            {
-                                if ax(s) as u16 >= self.puzzle.d {
-                                    return;
-                                }
-
-                                let side = if self.current_turn.side.is_some() {
-                                    self.current_turn.side
-                                } else if self.current_turn.layer == Some(TurnLayer::WholePuzzle) {
-                                    Some(0) // dummy value
-                                } else {
-                                    None
-                                };
-
-                                if let Some(side) = side {
-                                    if self.current_turn.from.is_none() {
-                                        self.current_keys = self.base_keys();
-                                    }
-                                    self.current_keys.push(c);
-
-                                    if let Some(from_raw) = self.current_turn.from {
-                                        let (from_norm, to_norm) = if self.current_turn.layer == Some(TurnLayer::WholePuzzle) {
-                                            let mut from_norm = ax(from_raw);
-                                            let mut to_norm = ax(s);
-                                            if (from_raw < 0) != (s < 0) {
-                                                std::mem::swap(&mut from_norm, &mut to_norm);
-                                            }
-                                            (from_norm, to_norm)
-                                        } else {
-                                            (from_raw, s)
-                                        };
-                                        let turn_out = self.perform_turn(side, from_norm, to_norm);
-
-                                        if turn_out.is_none() {
-                                            self.alert = self.prefs.alert_frames * 4 - 1;
-                                            let key_removal = if strict { 3 } else { 2 };
-                                            self.current_keys = self.current_keys
-                                                [..self.current_keys.len() - key_removal]
-                                                .to_string();
-                                        } else {
-                                            self.current_keys = self.canonical_turn_keys(from_raw, s);
-                                        }
-                                        self.current_turn.from = None;
-                                        if strict {
-                                            self.current_turn = Default::default();
-                                        }
-                                    } else {
-                                        self.current_turn.from = Some(s);
-                                    }
-                                }
-                            }
+                            self.try_three_key(c);
                         }
                         KeybindSet::FixedKey if self.puzzle.d == 3 => {
-                            let flip;
-                            if let Some(s) =
-                                self.prefs.axes.iter().position(|ax| ax.pos.keys.side == c)
-                            {
-                                if ax(s as i16) as u16 >= self.puzzle.d {
-                                    return;
-                                }
-                                if self.current_turn.layer.is_none()
-                                    || self.current_turn.side.is_some()
-                                {
-                                    self.flush_modes();
-                                }
-                                self.current_keys.push(c);
-                                self.current_turn.side = Some(s as i16);
-                                flip = true;
-                                just_pressed_side = true;
-                            } else if let Some(s) =
-                                self.prefs.axes.iter().position(|ax| ax.neg.keys.side == c)
-                            {
-                                if ax(s as i16) as u16 >= self.puzzle.d {
-                                    return;
-                                }
-                                if self.current_turn.layer.is_none()
-                                    || self.current_turn.side.is_some()
-                                {
-                                    self.flush_modes();
-                                }
-                                self.current_keys.push(c);
-                                self.current_turn.side = Some(!(s as i16));
-                                flip = true;
-                                just_pressed_side = true;
-                            } else {
-                                flip = false;
-                            }
-
-                            if let (Some(side), true) = (self.current_turn.side, just_pressed_side)
-                            {
-                                let _turn_out = if flip {
-                                    if side < 0 {
-                                        self.perform_turn(side, (!side + 1) % 3, (!side + 2) % 3)
-                                    } else {
-                                        self.perform_turn(side, (side + 2) % 3, (side + 1) % 3)
-                                    }
-                                } else if side < 0 {
-                                    self.perform_turn(side, (!side + 2) % 3, (!side + 1) % 3)
-                                } else {
-                                    self.perform_turn(side, (side + 1) % 3, (side + 2) % 3)
-                                };
-                            }
+                            self.try_fixed_3d(c);
                         }
                         KeybindSet::FixedKey => {
-                            let axis = self.get_axis_key(c);
-
-                            if !just_pressed_side
-                                && let Some(s) = axis {
-                                if ax(s) as u16 >= self.puzzle.d {
-                                    return;
-                                }
-                                if self.current_turn.fixed.is_empty() {
-                                    self.current_keys = self.base_keys();
-                                }
-                                self.current_keys.push(c);
-                                self.current_turn.fixed.push(s);
-
-                                let whole_puzzle =
-                                    self.current_turn.layer == Some(TurnLayer::WholePuzzle);
-                                let required_fixed = if whole_puzzle {
-                                    self.puzzle.d as usize - 2
-                                } else {
-                                    self.puzzle.d as usize - 3
-                                };
-
-                                let side = if whole_puzzle {
-                                    None
-                                } else {
-                                    self.current_turn.side
-                                };
-
-                                if side.is_some() || whole_puzzle {
-                                    if self.current_turn.fixed.len() == required_fixed {
-                                        let mut sign = true;
-                                        let mut axes = if let Some(side) = side {
-                                            vec![side]
-                                        } else {
-                                            vec![]
-                                        };
-                                        axes.extend(self.current_turn.fixed.iter().cloned());
-
-                                        for axis in &mut axes {
-                                            if *axis < 0 {
-                                                sign = !sign;
-                                                *axis = !*axis;
-                                            }
-                                        }
-
-                                        for axis in 0..self.puzzle.d as i16 {
-                                            if !axes.contains(&axis) {
-                                                axes.push(axis);
-                                            }
-                                        }
-
-                                        let mut turn_out = Some(()); // i wish we had try blocks
-
-                                        if axes.len() > self.puzzle.d as usize {
-                                            // there was a duplicate in axes
-                                            turn_out = None;
-                                        }
-
-                                        let turn_out = turn_out.and_then(|_| {
-                                            for i in 0..axes.len() {
-                                                for j in 0..i {
-                                                    if i > j {
-                                                        sign = !sign;
-                                                    }
-                                                }
-                                            }
-                                            let mut from = axes[axes.len() - 2];
-                                            let mut to = axes[axes.len() - 1];
-                                            if !sign {
-                                                std::mem::swap(&mut from, &mut to);
-                                            }
-                                            self.perform_turn(
-                                                side.unwrap_or(0),
-                                                from,
-                                                to,
-                                            )
-                                        });
-
-                                        if turn_out.is_none() {
-                                            self.alert = self.prefs.alert_frames * 4 - 1;
-                                            self.current_keys =
-                                                self.current_keys[..self.current_keys.len()
-                                                    - self.current_turn.fixed.len()]
-                                                    .to_string();
-                                        }
-                                        self.current_turn.fixed = vec![];
-                                    }
-                                }
-                            }
-                        } //_ => todo!(),
+                            self.try_fixed_key(c);
+                        }
                     }
                 }
 
@@ -729,76 +746,26 @@ impl AppState {
         }
     }
 
-    fn get_axis_key(&self, c: char) -> Option<i16> {
+    fn get_axis_key(&self, c: char) -> Option<KeyPress> {
         if self.keybind_set == KeybindSet::ThreeKeyStrict {
             return None;
         }
 
         match self.keybind_axial {
-            KeybindAxial::Axial => self.prefs.axes.iter().position(|ax| ax.axis_key == c),
+            KeybindAxial::Axial => self
+                .prefs
+                .axes
+                .iter()
+                .position(|ax| ax.axis_key == c)
+                .map(|s| KeyPress { ch: c, axis: s as i16 }),
             KeybindAxial::Side => self.prefs.axes.iter().enumerate().find_map(|(s, ax)| {
                 (ax.pos.keys.side == c)
-                    .then_some(s)
-                    .or_else(|| (ax.neg.keys.side == c).then_some(!s))
+                    .then_some(KeyPress { ch: c, axis: s as i16 })
+                    .or_else(|| {
+                        (ax.neg.keys.side == c).then_some(KeyPress { ch: c, axis: !(s as i16) })
+                    })
             }),
         }
-        .map(|s| s as i16)
-    }
-
-    fn base_keys(&self) -> String {
-        let mut s = String::new();
-        if let Some(TurnLayer::Layer(l)) = self.current_turn.layer {
-            if let Some(&ch) = self.prefs.global_keys.layers.get(l as usize) {
-                s.push(ch);
-            }
-        } else if self.current_turn.layer == Some(TurnLayer::WholePuzzle) {
-            s.push(self.prefs.global_keys.rotate);
-            return s;
-        }
-        if let Some(side) = self.current_turn.side {
-            if side >= 0 {
-                if let Some(axis) = self.prefs.axes.get(side as usize) {
-                    s.push(axis.pos.keys.select);
-                }
-            } else if let Some(axis) = self.prefs.axes.get((!side) as usize) {
-                s.push(axis.neg.keys.select);
-            }
-        }
-        s
-    }
-
-    fn axis_key_char(&self, axis: i16) -> Option<char> {
-        if self.keybind_set == KeybindSet::ThreeKeyStrict {
-            if axis >= 0 {
-                self.prefs.axes.get(axis as usize).map(|ax| ax.pos.keys.select)
-            } else {
-                self.prefs.axes.get((!axis) as usize).map(|ax| ax.neg.keys.select)
-            }
-        } else {
-            match self.keybind_axial {
-                KeybindAxial::Axial => {
-                    self.prefs.axes.get(ax(axis) as usize).map(|ax| ax.axis_key)
-                }
-                KeybindAxial::Side => {
-                    if axis >= 0 {
-                        self.prefs.axes.get(axis as usize).map(|ax| ax.pos.keys.side)
-                    } else {
-                        self.prefs.axes.get((!axis) as usize).map(|ax| ax.neg.keys.side)
-                    }
-                }
-            }
-        }
-    }
-
-    fn canonical_turn_keys(&self, from: i16, to: i16) -> String {
-        let mut s = self.base_keys();
-        if let Some(ch) = self.axis_key_char(from) {
-            s.push(ch);
-        }
-        if let Some(ch) = self.axis_key_char(to) {
-            s.push(ch);
-        }
-        s
     }
 
     fn perform_turn(&mut self, side: i16, from: i16, to: i16) -> Option<()> {
@@ -883,7 +850,13 @@ impl AppState {
             return message.to_string();
         }
         match self.mode {
-            AppMode::Turn => self.current_keys.clone(),
+            AppMode::Turn => {
+                if !self.last_turn_keys.is_empty() {
+                    self.last_turn_keys.clone()
+                } else {
+                    self.current_turn.current_keys()
+                }
+            }
             AppMode::LiveFilter => format!("live filter: {}", self.live_filter_string),
         }
     }

--- a/src/state.rs
+++ b/src/state.rs
@@ -566,13 +566,9 @@ impl AppState {
             self.current_turn.fixed.clear();
             return;
         }
-        for i in 0..axes.len() {
-            for j in 0..i {
-                if i > j {
-                    sign = !sign;
-                }
-            }
-        }
+        // The sign is determined solely by the number of negative axis
+        // keys: all-positive = counterclockwise, each negative flips it.
+        // The permutation order does not affect rotation direction.
         let mut from = axes[axes.len() - 2];
         let mut to = axes[axes.len() - 1];
         if !sign {
@@ -1456,8 +1452,7 @@ pub fn main_inner() -> Result<(), Box<dyn std::error::Error>> {
                 ch = if (state.current_turn.side.is_none()
                         && state.current_turn.layer != Some(TurnLayer::WholePuzzle))
                     || (state.keybind_set == KeybindSet::FixedKey
-                        && state.puzzle.d == 3
-                        && state.current_turn.layer != Some(TurnLayer::WholePuzzle))
+                        && state.puzzle.d == 3)
                     || state.keybind_set == KeybindSet::ThreeKeyStrict
                 {
                     if *side >= 0 {

--- a/src/state.rs
+++ b/src/state.rs
@@ -912,6 +912,7 @@ pub fn main_inner() -> Result<(), Box<dyn std::error::Error>> {
     let (mut term_w, mut term_h) = terminal::size()?;
     let mut scroll_x: i16 = 0;
     let mut scroll_y: i16 = 0;
+    let mut prev_mouse_pos: Option<(u16, u16)> = None;
 
     'event: loop {
         let previous_message = state.get_message();
@@ -1010,6 +1011,30 @@ pub fn main_inner() -> Result<(), Box<dyn std::error::Error>> {
                             scroll_x = (scroll_x + SCROLL_STEP_WHEEL)
                                 .min(layout.width.saturating_sub(term_w) as i16);
                             continue;
+                        }
+                        MouseEventKind::Drag(_) => {
+                            if let Some((prev_col, prev_row)) = prev_mouse_pos {
+                                let dx = prev_col as i16 - column as i16;
+                                let dy = prev_row as i16 - row as i16;
+                                scroll_x = (scroll_x + dx)
+                                    .clamp(0, layout.width.saturating_sub(term_w) as i16);
+                                scroll_y = (scroll_y + dy).clamp(
+                                    0,
+                                    layout
+                                        .height
+                                        .saturating_sub(term_h.saturating_sub(1))
+                                        as i16,
+                                );
+                            }
+                            prev_mouse_pos = Some((column, row));
+                            continue;
+                        }
+                        MouseEventKind::Up(_) => {
+                            prev_mouse_pos = None;
+                            continue;
+                        }
+                        MouseEventKind::Down(_) => {
+                            prev_mouse_pos = Some((column, row));
                         }
                         _ => {}
                     }

--- a/src/state.rs
+++ b/src/state.rs
@@ -1112,6 +1112,8 @@ pub fn main_inner() -> Result<(), Box<dyn std::error::Error>> {
     const SCROLL_STEP_WHEEL: i16 = 3;
 
     let (mut term_w, mut term_h) = terminal::size()?;
+    let mut scroll_max_x = layout.width.saturating_sub(term_w) as i16;
+    let mut scroll_max_y = layout.height.saturating_sub(term_h.saturating_sub(2)) as i16;
     let mut scroll_x: i16 = 0;
     let mut scroll_y: i16 = 0;
     let mut prev_mouse_pos: Option<(u16, u16)> = None;
@@ -1165,12 +1167,7 @@ pub fn main_inner() -> Result<(), Box<dyn std::error::Error>> {
                     }
                     KeyCode::Down => {
                         let step = (term_h.saturating_sub(2) as i16 * 3 / 4).max(1);
-                        scroll_y = (scroll_y + step).min(
-                            layout
-                                .height
-                                .saturating_sub(term_h.saturating_sub(2))
-                                as i16,
-                        );
+                        scroll_y = (scroll_y + step).min(scroll_max_y);
                     }
                     KeyCode::Left => {
                         let step = (term_w as i16 * 3 / 4).max(1);
@@ -1178,8 +1175,7 @@ pub fn main_inner() -> Result<(), Box<dyn std::error::Error>> {
                     }
                     KeyCode::Right => {
                         let step = (term_w as i16 * 3 / 4).max(1);
-                        scroll_x = (scroll_x + step)
-                            .min(layout.width.saturating_sub(term_w) as i16);
+                        scroll_x = (scroll_x + step).min(scroll_max_x);
                     }
                     _ => (),
                 },
@@ -1201,15 +1197,9 @@ pub fn main_inner() -> Result<(), Box<dyn std::error::Error>> {
                         }
                         MouseEventKind::ScrollDown => {
                             if modifiers.contains(KeyModifiers::SHIFT) {
-                                scroll_x = (scroll_x + SCROLL_STEP_WHEEL)
-                                    .min(layout.width.saturating_sub(term_w) as i16);
+                                scroll_x = (scroll_x + SCROLL_STEP_WHEEL).min(scroll_max_x);
                             } else {
-                                scroll_y = (scroll_y + SCROLL_STEP_WHEEL).min(
-                                    layout
-                                        .height
-                                        .saturating_sub(term_h.saturating_sub(2))
-                                        as i16,
-                                );
+                                scroll_y = (scroll_y + SCROLL_STEP_WHEEL).min(scroll_max_y);
                             }
                             continue;
                         }
@@ -1218,23 +1208,15 @@ pub fn main_inner() -> Result<(), Box<dyn std::error::Error>> {
                             continue;
                         }
                         MouseEventKind::ScrollRight => {
-                            scroll_x = (scroll_x + SCROLL_STEP_WHEEL)
-                                .min(layout.width.saturating_sub(term_w) as i16);
+                            scroll_x = (scroll_x + SCROLL_STEP_WHEEL).min(scroll_max_x);
                             continue;
                         }
                         MouseEventKind::Drag(_) => {
                             if let Some((prev_col, prev_row)) = prev_mouse_pos {
                                 let dx = prev_col as i16 - column as i16;
                                 let dy = prev_row as i16 - row as i16;
-                                scroll_x = (scroll_x + dx)
-                                    .clamp(0, layout.width.saturating_sub(term_w) as i16);
-                                scroll_y = (scroll_y + dy).clamp(
-                                    0,
-                                    layout
-                                        .height
-                                        .saturating_sub(term_h.saturating_sub(2))
-                                        as i16,
-                                );
+                                scroll_x = (scroll_x + dx).clamp(0, scroll_max_x);
+                                scroll_y = (scroll_y + dy).clamp(0, scroll_max_y);
                             }
                             prev_mouse_pos = Some((column, row));
                             dragged = true;
@@ -1286,14 +1268,10 @@ pub fn main_inner() -> Result<(), Box<dyn std::error::Error>> {
                     let (new_w, new_h) = terminal::size()?;
                     term_w = new_w;
                     term_h = new_h;
-                    scroll_x =
-                        scroll_x.min(layout.width.saturating_sub(term_w) as i16);
-                    scroll_y = scroll_y.min(
-                        layout
-                            .height
-                            .saturating_sub(term_h.saturating_sub(2))
-                            as i16,
-                    );
+                    scroll_max_x = layout.width.saturating_sub(term_w) as i16;
+                    scroll_max_y = layout.height.saturating_sub(term_h.saturating_sub(2)) as i16;
+                    scroll_x = scroll_x.min(scroll_max_x);
+                    scroll_y = scroll_y.min(scroll_max_y);
                     stdout.execute(terminal::Clear(terminal::ClearType::All))?;
                     just_resized = true;
                 }

--- a/src/state.rs
+++ b/src/state.rs
@@ -387,7 +387,6 @@ impl AppState {
                         }
                     } else if c == self.prefs.global_keys.undo {
                         self.flush_modes();
-                        self.rev_stack.clear();
                         let undid = self.undo_history.pop();
                         match undid {
                             None => {
@@ -395,12 +394,12 @@ impl AppState {
                             }
                             Some(undid) => {
                                 self.puzzle.turn(undid.inverse());
-                                self.redo_history.push(undid)
+                                self.redo_history.push(undid);
+                                self.rev_stack_adjust();
                             }
                         }
                     } else if c == self.prefs.global_keys.redo {
                         self.flush_modes();
-                        self.rev_stack.clear();
                         let redid = self.redo_history.pop();
                         match redid {
                             None => {
@@ -408,7 +407,8 @@ impl AppState {
                             }
                             Some(redid) => {
                                 self.puzzle.turn(redid.clone());
-                                self.undo_history.push(redid)
+                                self.undo_history.push(redid);
+                                self.rev_stack_adjust();
                             }
                         }
                     } else if c == self.prefs.global_keys.next_filter {
@@ -770,11 +770,14 @@ impl AppState {
             }
         }
 
-        self.undo_history.push(turn.clone());
+        let turn_clone = turn.clone();
         let turn_out = self.puzzle.turn(turn);
 
-        if turn_out.is_some() && self.puzzle.is_solved() {
-            self.message = Some("solved!".to_string());
+        if turn_out.is_some() {
+            self.undo_history.push(turn_clone);
+            if self.puzzle.is_solved() {
+                self.message = Some("solved!".to_string());
+            }
         }
 
         turn_out
@@ -884,6 +887,28 @@ impl AppState {
             s.push_str(&(self.undo_history.len() - pos).to_string());
         }
         s
+    }
+
+    fn rev_stack_adjust(&mut self) {
+        let len = self.undo_history.len();
+        self.rev_stack.retain_mut(|entry| {
+            if entry.start > len {
+                if entry.end.is_none() {
+                    entry.start = len;
+                } else {
+                    return false;
+                }
+            }
+            if let Some(ref mut end) = entry.end {
+                if *end > len {
+                    *end = len;
+                }
+                if *end == entry.start {
+                    return false;
+                }
+            }
+            true
+        });
     }
 }
 

--- a/src/state.rs
+++ b/src/state.rs
@@ -907,6 +907,12 @@ pub fn main_inner() -> Result<(), Box<dyn std::error::Error>> {
 
     let stdout_manager = StdoutManager;
 
+    const SCROLL_STEP_WHEEL: i16 = 3;
+
+    let (mut term_w, mut term_h) = terminal::size()?;
+    let mut scroll_x: i16 = 0;
+    let mut scroll_y: i16 = 0;
+
     'event: loop {
         let previous_message = state.get_message();
         let previous_hovered = state.hovered;
@@ -914,6 +920,7 @@ pub fn main_inner() -> Result<(), Box<dyn std::error::Error>> {
         let mut just_resized = false;
 
         let frame_begin = Instant::now();
+        let scroll_before = (scroll_x, scroll_y);
 
         while event::poll(Duration::from_millis(0))? {
             match event::read()? {
@@ -941,12 +948,72 @@ pub fn main_inner() -> Result<(), Box<dyn std::error::Error>> {
                     KeyCode::Backspace => {
                         state.process_key(BACKSPACE_CODE);
                     }
+                    KeyCode::Up => {
+                        let step = (term_h.saturating_sub(1) as i16 * 3 / 4).max(1);
+                        scroll_y = (scroll_y - step).max(0);
+                    }
+                    KeyCode::Down => {
+                        let step = (term_h.saturating_sub(1) as i16 * 3 / 4).max(1);
+                        scroll_y = (scroll_y + step).min(
+                            layout
+                                .height
+                                .saturating_sub(term_h.saturating_sub(1))
+                                as i16,
+                        );
+                    }
+                    KeyCode::Left => {
+                        let step = (term_w as i16 * 3 / 4).max(1);
+                        scroll_x = (scroll_x - step).max(0);
+                    }
+                    KeyCode::Right => {
+                        let step = (term_w as i16 * 3 / 4).max(1);
+                        scroll_x = (scroll_x + step)
+                            .min(layout.width.saturating_sub(term_w) as i16);
+                    }
                     _ => (),
                 },
                 Event::Mouse(MouseEvent {
-                    kind, column, row, ..
+                    kind,
+                    column,
+                    row,
+                    modifiers,
+                    ..
                 }) => {
-                    let key = (column as i16, row as i16);
+                    match kind {
+                        MouseEventKind::ScrollUp => {
+                            if modifiers.contains(KeyModifiers::SHIFT) {
+                                scroll_x = (scroll_x - SCROLL_STEP_WHEEL).max(0);
+                            } else {
+                                scroll_y = (scroll_y - SCROLL_STEP_WHEEL).max(0);
+                            }
+                            continue;
+                        }
+                        MouseEventKind::ScrollDown => {
+                            if modifiers.contains(KeyModifiers::SHIFT) {
+                                scroll_x = (scroll_x + SCROLL_STEP_WHEEL)
+                                    .min(layout.width.saturating_sub(term_w) as i16);
+                            } else {
+                                scroll_y = (scroll_y + SCROLL_STEP_WHEEL).min(
+                                    layout
+                                        .height
+                                        .saturating_sub(term_h.saturating_sub(1))
+                                        as i16,
+                                );
+                            }
+                            continue;
+                        }
+                        MouseEventKind::ScrollLeft => {
+                            scroll_x = (scroll_x - SCROLL_STEP_WHEEL).max(0);
+                            continue;
+                        }
+                        MouseEventKind::ScrollRight => {
+                            scroll_x = (scroll_x + SCROLL_STEP_WHEEL)
+                                .min(layout.width.saturating_sub(term_w) as i16);
+                            continue;
+                        }
+                        _ => {}
+                    }
+                    let key = (column as i16 + scroll_x, row as i16 + scroll_y);
                     let sticker = layout.points.get(&key);
                     if let Some(sticker) = sticker {
                         match kind {
@@ -970,6 +1037,17 @@ pub fn main_inner() -> Result<(), Box<dyn std::error::Error>> {
                     }
                 }
                 Event::Resize(_, _) => {
+                    let (new_w, new_h) = terminal::size()?;
+                    term_w = new_w;
+                    term_h = new_h;
+                    scroll_x =
+                        scroll_x.min(layout.width.saturating_sub(term_w) as i16);
+                    scroll_y = scroll_y.min(
+                        layout
+                            .height
+                            .saturating_sub(term_h.saturating_sub(1))
+                            as i16,
+                    );
                     stdout.execute(terminal::Clear(terminal::ClearType::All))?;
                     just_resized = true;
                 }
@@ -977,27 +1055,37 @@ pub fn main_inner() -> Result<(), Box<dyn std::error::Error>> {
             }
         }
 
+        if (scroll_x, scroll_y) != scroll_before {
+            stdout.execute(terminal::Clear(terminal::ClearType::All))?;
+        }
+
         let message = state.get_message();
 
         if just_resized {
             stdout
-                .queue(cursor::MoveTo(0, layout.height))?
+                .queue(cursor::MoveTo(0, term_h.saturating_sub(1)))?
                 .queue(terminal::Clear(terminal::ClearType::All))?
                 .flush()?;
         }
         if previous_message != message {
             stdout
-                .queue(cursor::MoveTo(0, layout.height))?
+                .queue(cursor::MoveTo(0, term_h.saturating_sub(1)))?
                 .queue(terminal::Clear(terminal::ClearType::CurrentLine))?
                 .queue(style::Print(message))?;
         }
 
         if let Some((x, y)) = previous_hovered {
-            erase_brackets(&mut stdout, x, y)?;
+            erase_brackets(&mut stdout, x - scroll_x, y - scroll_y)?;
         }
 
         if let Some((x, y)) = state.hovered {
-            draw_brackets(&mut stdout, x, y, ClickedStyle::Hovered, &state.prefs)?;
+            draw_brackets(
+                &mut stdout,
+                x - scroll_x,
+                y - scroll_y,
+                ClickedStyle::Hovered,
+                &state.prefs,
+            )?;
         }
 
         let clicked_stickers = state.clicked_stickers();
@@ -1008,6 +1096,15 @@ pub fn main_inner() -> Result<(), Box<dyn std::error::Error>> {
             .collect();
 
         for ((x, y), pos) in &layout.points {
+            let screen_x = *x - scroll_x;
+            let screen_y = *y - scroll_y;
+            if screen_x < 0
+                || screen_x >= term_w as i16
+                || screen_y < 0
+                || screen_y >= term_h.saturating_sub(1) as i16
+            {
+                continue;
+            }
             // in this loop we are more efficient by not flushing the buffer.
             let ch;
             let color;
@@ -1040,7 +1137,7 @@ pub fn main_inner() -> Result<(), Box<dyn std::error::Error>> {
                     state.prefs.axes[(!side) as usize].neg.color
                 };
                 stdout
-                    .queue(cursor::MoveTo(*x as u16, *y as u16))?
+                    .queue(cursor::MoveTo(screen_x as u16, screen_y as u16))?
                     .queue(style::PrintStyledContent(ch.with(color)))?;
             } else if !matches!(layout.keybind_hints.get(&(*x, *y)), Some(Some(_))) {
                 if state.alert % (state.prefs.alert_frames * 2) >= state.prefs.alert_frames {
@@ -1055,19 +1152,19 @@ pub fn main_inner() -> Result<(), Box<dyn std::error::Error>> {
                     };
                 }
                 stdout
-                    .queue(cursor::MoveTo(*x as u16, *y as u16))?
+                    .queue(cursor::MoveTo(screen_x as u16, screen_y as u16))?
                     .queue(style::PrintStyledContent(ch.with(color)))?;
             }
 
             if previous_clicked_stickers.get(pos) != clicked_stickers.get(pos) {
-                erase_locs.insert((*x, *y));
+                erase_locs.insert((screen_x, screen_y));
             }
 
             if let Some(style) = clicked_stickers.get(pos) {
                 clicked_locs
                     .get_mut(style)
                     .expect("contains")
-                    .insert((*x, *y));
+                    .insert((screen_x, screen_y));
             }
         }
 
@@ -1082,6 +1179,15 @@ pub fn main_inner() -> Result<(), Box<dyn std::error::Error>> {
         }
 
         for ((x, y), side) in &layout.keybind_hints {
+            let screen_x = *x - scroll_x;
+            let screen_y = *y - scroll_y;
+            if screen_x < 0
+                || screen_x >= term_w as i16
+                || screen_y < 0
+                || screen_y >= term_h.saturating_sub(1) as i16
+            {
+                continue;
+            }
             // in this loop we are more efficient by not flushing the buffer.
             let ch;
             let color;
@@ -1116,13 +1222,12 @@ pub fn main_inner() -> Result<(), Box<dyn std::error::Error>> {
                 color = state.prefs.global_colors.piece;
 
                 stdout
-                    .queue(cursor::MoveTo(*x as u16, *y as u16))?
+                    .queue(cursor::MoveTo(screen_x as u16, screen_y as u16))?
                     .queue(style::PrintStyledContent(ch.with(color)))?;
             }
-            //state.message = format!("{:?}", (x, y, side)).into();
         }
 
-        stdout.queue(cursor::MoveTo(0, layout.height))?.flush()?;
+        stdout.queue(cursor::MoveTo(0, term_h.saturating_sub(1)))?.flush()?;
 
         if state.alert > 0 {
             state.alert -= 1;

--- a/src/state.rs
+++ b/src/state.rs
@@ -448,6 +448,7 @@ impl AppState {
                         self.current_turn.layer = Some(TurnLayer::Layer(s as i16));
                     } else if !self.awaiting_side_as_axis()
                         && let Some(s) = self.get_side(c)
+                        && !(self.current_turn.side.is_some() && self.get_axis_key(c).is_some())
                     {
                         if s.max(!s) as u16 >= self.puzzle.d {
                             return;
@@ -479,7 +480,7 @@ impl AppState {
 
                             if (self.current_turn.side.is_some()
                                 || self.current_turn.layer == Some(TurnLayer::WholePuzzle))
-                                && !(strict && just_pressed_side)
+                                && !just_pressed_side
                                 && let Some(s) = axis
                             {
                                 if ax(s) as u16 >= self.puzzle.d {
@@ -570,7 +571,8 @@ impl AppState {
                         KeybindSet::FixedKey => {
                             let axis = self.get_axis_key(c);
 
-                            if let Some(s) = axis {
+                            if !just_pressed_side
+                                && let Some(s) = axis {
                                 if ax(s) as u16 >= self.puzzle.d {
                                     return;
                                 }

--- a/src/state.rs
+++ b/src/state.rs
@@ -494,7 +494,12 @@ impl AppState {
 
                                     if let Some(from_raw) = self.current_turn.from {
                                         let (from_norm, to_norm) = if self.current_turn.layer == Some(TurnLayer::WholePuzzle) {
-                                            (ax(from_raw), ax(s))
+                                            let mut from_norm = ax(from_raw);
+                                            let mut to_norm = ax(s);
+                                            if (from_raw < 0) != (s < 0) {
+                                                std::mem::swap(&mut from_norm, &mut to_norm);
+                                            }
+                                            (from_norm, to_norm)
                                         } else {
                                             (from_raw, s)
                                         };

--- a/src/state.rs
+++ b/src/state.rs
@@ -953,6 +953,9 @@ pub fn main_inner() -> Result<(), Box<dyn std::error::Error>> {
     let mut scroll_x: i16 = 0;
     let mut scroll_y: i16 = 0;
     let mut prev_mouse_pos: Option<(u16, u16)> = None;
+    let mut dragged = false;
+    let mut last_empty_click: Option<Instant> = None;
+    const DOUBLE_CLICK_THRESHOLD: Duration = Duration::from_millis(500);
 
     'event: loop {
         let previous_message = state.get_message();
@@ -1067,38 +1070,49 @@ pub fn main_inner() -> Result<(), Box<dyn std::error::Error>> {
                                 );
                             }
                             prev_mouse_pos = Some((column, row));
+                            dragged = true;
                             continue;
                         }
                         MouseEventKind::Up(_) => {
                             prev_mouse_pos = None;
-                            continue;
+                            if std::mem::replace(&mut dragged, false) {
+                                continue;
+                            }
                         }
                         MouseEventKind::Down(_) => {
                             prev_mouse_pos = Some((column, row));
+                            dragged = false;
+                            continue;
                         }
                         _ => {}
                     }
                     let key = (column as i16 + scroll_x, row as i16 + scroll_y);
                     let sticker = layout.points.get(&key);
                     if let Some(sticker) = sticker {
-                        match kind {
-                            MouseEventKind::Down(_button) => {
-                                let original_length = state.clicked.len();
-                                state.clicked.retain(|st| {
-                                    st.iter()
-                                        .zip(sticker.iter())
-                                        .any(|(a, b)| (a - b).abs() > 1)
-                                });
+                        if let MouseEventKind::Up(_) = kind {
+                            let original_length = state.clicked.len();
+                            state.clicked.retain(|st| {
+                                st.iter()
+                                    .zip(sticker.iter())
+                                    .any(|(a, b)| (a - b).abs() > 1)
+                            });
 
-                                if original_length == state.clicked.len() {
-                                    state.clicked.push(sticker.clone());
-                                }
+                            if original_length == state.clicked.len() {
+                                state.clicked.push(sticker.clone());
                             }
-                            MouseEventKind::Moved => {
-                                state.hovered = Some(key);
-                            }
-                            _ => {}
                         }
+                    } else if let MouseEventKind::Up(_) = kind {
+                        if let Some(prev) = last_empty_click
+                            && prev.elapsed() < DOUBLE_CLICK_THRESHOLD
+                        {
+                            state.clicked.clear();
+                            last_empty_click = None;
+                        } else {
+                            last_empty_click = Some(Instant::now());
+                        }
+                    }
+                    if let MouseEventKind::Moved = kind {
+                        state.hovered = sticker.map(|_| key);
                     }
                 }
                 Event::Resize(_, _) => {


### PR DESCRIPTION
What's new

  - Viewport panning: drag with the mouse to pan, scroll with touchpad or mouse wheel, or press arrow keys to move, `Ctrl`+arrow keys for precise 1-character scrolling adjustments. Works with all puzzle sizes — larger puzzles no longer need to fit the terminal.
  - Semi-compact mode (-c): reduce gaps between dims instead of clearing them.
  - Shortcuts (`F1`–`F4` or `Q`/`W`/`E`/`R`): record move sequences with `F1`/`F2`, replay inverses with `F3`, apply commutator with `F4`. Keys can be customized. Block size shown on the second status line. Similar to MC7D.
  - Cross-platform Ctrl+C: use the ctrlc crate.
  - Status bar flushs correctly to show the last performed twist.
  - Keybind Hints for n=2 Layout.
  - Sticker marking: marks on mouse release (no accidental marks while dragging). Double-click empty space clears all marks.
  - Keys in different fields (select vs side vs axis_key) never conflict now. All 10 axes in `default_prefs.json` now have complete selector, axis, and side key bindings.
  - Prefs key validation: duplicate keys within the same column are caught with clear error messages at startup.

  Improved

  - Rotation input refactored: KeyPress struct bundles character and axis value. Mode logic extracted to `try_three_key` / `try_fixed_key`. Status bar holds last completed rotation until next keypress.
  - ThreeKey strict: full reset the clicking status after a twist. 
  - x key consistent across modes: flushes, sets state, and shows axis key hints correctly in ThreeKey, ThreeKeyStrict, and FixedKey. No need to select a side after pressing `x`.
  - Restrictions lifted: FixedKey available for 2-layer puzzles. Side mode no longer blocked at d > 6.
  - Doc comments on all non-trivial functions